### PR TITLE
add record timestamp from structset

### DIFF
--- a/repo.go
+++ b/repo.go
@@ -4,11 +4,6 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	"time"
-)
-
-var (
-	now = time.Now
 )
 
 // Repo defines rel repository.
@@ -154,7 +149,6 @@ func (r Repo) Insert(record interface{}, changers ...Changer) error {
 
 func (r Repo) insert(doc *document, changes Changes) error {
 	var (
-		t        = now()
 		pField   = doc.PrimaryField()
 		queriers = BuildQuery(doc.Table())
 	)
@@ -162,9 +156,6 @@ func (r Repo) insert(doc *document, changes Changes) error {
 	if err := r.saveBelongsTo(doc, &changes); err != nil {
 		return err
 	}
-
-	r.putTimestamp(doc, &changes, "created_at", t)
-	r.putTimestamp(doc, &changes, "updated_at", t)
 
 	id, err := r.Adapter().Insert(queriers, changes, r.logger...)
 	if err != nil {
@@ -292,8 +283,6 @@ func (r Repo) update(doc *document, changes Changes, filter FilterQuery) error {
 		var (
 			queriers = BuildQuery(doc.Table(), filter)
 		)
-
-		r.putTimestamp(doc, &changes, "updated_at", now())
 
 		if err := r.adapter.Update(queriers, changes, r.logger...); err != nil {
 			return err
@@ -712,10 +701,4 @@ func (r Repo) Transaction(fn func(Repo) error) error {
 	}()
 
 	return err
-}
-
-func (r Repo) putTimestamp(doc *document, changes *Changes, field string, t time.Time) {
-	if typ, ok := doc.Type(field); ok && typ == rtTime {
-		changes.SetValue(field, t)
-	}
 }

--- a/structset_test.go
+++ b/structset_test.go
@@ -48,15 +48,15 @@ func BenchmarkStructset(b *testing.B) {
 func TestStructset(t *testing.T) {
 	var (
 		user = &User{
-			ID:        1,
-			Name:      "Luffy",
-			Age:       20,
-			CreatedAt: time.Now(),
+			ID:   1,
+			Name: "Luffy",
+			Age:  20,
 		}
 		changes = BuildChanges(
 			Set("name", "Luffy"),
 			Set("age", 20),
-			Set("created_at", user.CreatedAt),
+			Set("created_at", now()),
+			Set("updated_at", now()),
 		)
 	)
 
@@ -82,7 +82,7 @@ func TestStructset_withAssoc(t *testing.T) {
 		userChanges = BuildChanges(
 			Set("name", "Luffy"),
 			Set("age", 20),
-			Set("created_at", user.CreatedAt),
+			Set("updated_at", now()),
 		)
 		transaction1Changes = BuildChanges(
 			Set("item", "Sword"),
@@ -99,4 +99,25 @@ func TestStructset_withAssoc(t *testing.T) {
 	userChanges.SetAssoc("address", addressChanges)
 
 	assertChanges(t, userChanges, BuildChanges(NewStructset(user)))
+}
+
+func TestStructset_invalidCreatedAtType(t *testing.T) {
+	type tmp struct {
+		ID        int
+		Name      string
+		CreatedAt int
+	}
+
+	var (
+		user = &tmp{
+			Name:      "Luffy",
+			CreatedAt: 1,
+		}
+		changes = BuildChanges(
+			Set("name", "Luffy"),
+			Set("created_at", 1),
+		)
+	)
+
+	assertChanges(t, changes, BuildChanges(NewStructset(user)))
 }


### PR DESCRIPTION
- Add record timestamp only if structset is used to update or create a record.
- InsertAll using structset now will also include timestamp.
- Updating using map or via single field modifier will no longer include timestamp update.