### PR TITLE
In and Not In Query helper for concrete types

### DIFF
--- a/filter_query.go
+++ b/filter_query.go
@@ -383,6 +383,45 @@ func In(field string, values ...interface{}) FilterQuery {
 	}
 }
 
+// InInt check whethers integer values of the field is included.
+func InInt(field string, values []int) FilterQuery {
+	var (
+		ivalues = make([]interface{}, len(values))
+	)
+
+	for i := range values {
+		ivalues[i] = values[i]
+	}
+
+	return In(field, ivalues...)
+}
+
+// InUint check whethers unsigned integer values of the field is included.
+func InUint(field string, values []uint) FilterQuery {
+	var (
+		ivalues = make([]interface{}, len(values))
+	)
+
+	for i := range values {
+		ivalues[i] = values[i]
+	}
+
+	return In(field, ivalues...)
+}
+
+// InString check whethers string values of the field is included.
+func InString(field string, values []string) FilterQuery {
+	var (
+		ivalues = make([]interface{}, len(values))
+	)
+
+	for i := range values {
+		ivalues[i] = values[i]
+	}
+
+	return In(field, ivalues...)
+}
+
 // Nin check whethers value of the field is not included in values.
 func Nin(field string, values ...interface{}) FilterQuery {
 	return FilterQuery{
@@ -390,6 +429,45 @@ func Nin(field string, values ...interface{}) FilterQuery {
 		Field: field,
 		Value: values,
 	}
+}
+
+// NinInt check whethers integer values of the is not included.
+func NinInt(field string, values []int) FilterQuery {
+	var (
+		ivalues = make([]interface{}, len(values))
+	)
+
+	for i := range values {
+		ivalues[i] = values[i]
+	}
+
+	return Nin(field, ivalues...)
+}
+
+// NinUint check whethers unsigned integer values of the is not included.
+func NinUint(field string, values []uint) FilterQuery {
+	var (
+		ivalues = make([]interface{}, len(values))
+	)
+
+	for i := range values {
+		ivalues[i] = values[i]
+	}
+
+	return Nin(field, ivalues...)
+}
+
+// NinString check whethers string values of the is not included.
+func NinString(field string, values []string) FilterQuery {
+	var (
+		ivalues = make([]interface{}, len(values))
+	)
+
+	for i := range values {
+		ivalues[i] = values[i]
+	}
+
+	return Nin(field, ivalues...)
 }
 
 // Like compares value of field to match string pattern.

--- a/filter_query_test.go
+++ b/filter_query_test.go
@@ -835,6 +835,30 @@ func TestIn(t *testing.T) {
 	}, rel.In("field", "value1", "value2"))
 }
 
+func TestInInt(t *testing.T) {
+	assert.Equal(t, rel.FilterQuery{
+		Type:  rel.FilterInOp,
+		Field: "field",
+		Value: []interface{}{1, 2},
+	}, rel.InInt("field", []int{1, 2}))
+}
+
+func TestInUint(t *testing.T) {
+	assert.Equal(t, rel.FilterQuery{
+		Type:  rel.FilterInOp,
+		Field: "field",
+		Value: []interface{}{uint(1), uint(2)},
+	}, rel.InUint("field", []uint{1, 2}))
+}
+
+func TestInString(t *testing.T) {
+	assert.Equal(t, rel.FilterQuery{
+		Type:  rel.FilterInOp,
+		Field: "field",
+		Value: []interface{}{"1", "2"},
+	}, rel.InString("field", []string{"1", "2"}))
+}
+
 func TestNin(t *testing.T) {
 	assert.Equal(t, rel.FilterQuery{
 		Type:  rel.FilterNinOp,
@@ -843,6 +867,29 @@ func TestNin(t *testing.T) {
 	}, rel.Nin("field", "value1", "value2"))
 }
 
+func TestNinInt(t *testing.T) {
+	assert.Equal(t, rel.FilterQuery{
+		Type:  rel.FilterNinOp,
+		Field: "field",
+		Value: []interface{}{1, 2},
+	}, rel.NinInt("field", []int{1, 2}))
+}
+
+func TestNinUint(t *testing.T) {
+	assert.Equal(t, rel.FilterQuery{
+		Type:  rel.FilterNinOp,
+		Field: "field",
+		Value: []interface{}{uint(1), uint(2)},
+	}, rel.NinUint("field", []uint{1, 2}))
+}
+
+func TestNinString(t *testing.T) {
+	assert.Equal(t, rel.FilterQuery{
+		Type:  rel.FilterNinOp,
+		Field: "field",
+		Value: []interface{}{"1", "2"},
+	}, rel.NinString("field", []string{"1", "2"}))
+}
 func TestLike(t *testing.T) {
 	assert.Equal(t, rel.FilterQuery{
 		Type:  rel.FilterLikeOp,


### PR DESCRIPTION
Add helper to make working with concrete types and avoid manually converting each values to interface that can be tedious.