### PR TITLE
Use verbs for Repository method naming

### DIFF
--- a/adapter/specs/delete.go
+++ b/adapter/specs/delete.go
@@ -18,7 +18,7 @@ func Delete(t *testing.T, repo rel.Repository) {
 	assert.NotEqual(t, 0, user.ID)
 
 	assert.Nil(t, repo.Delete(&user))
-	assert.Equal(t, rel.NoResultError{}, repo.One(&user, where.Eq("id", user.ID)))
+	assert.Equal(t, rel.NoResultError{}, repo.Find(&user, where.Eq("id", user.ID)))
 
 }
 
@@ -32,7 +32,7 @@ func DeleteAll(t *testing.T, repo rel.Repository) {
 	assert.NotEqual(t, 0, user.ID)
 
 	assert.Nil(t, repo.Delete(&user))
-	assert.NotNil(t, repo.One(&user, where.Eq("id", user.ID)))
+	assert.NotNil(t, repo.Find(&user, where.Eq("id", user.ID)))
 
 	repo.MustInsert(&User{Name: "delete", Age: 100})
 	repo.MustInsert(&User{Name: "delete", Age: 100})
@@ -47,12 +47,12 @@ func DeleteAll(t *testing.T, repo rel.Repository) {
 		statement, _ := builder.Delete(query.Collection, query.WhereQuery)
 		t.Run("Delete|"+statement, func(t *testing.T) {
 			var result []User
-			assert.Nil(t, repo.All(&result, query))
+			assert.Nil(t, repo.FindAll(&result, query))
 			assert.NotEqual(t, 0, len(result))
 
 			assert.Nil(t, repo.DeleteAll(query))
 
-			assert.Nil(t, repo.All(&result, query))
+			assert.Nil(t, repo.FindAll(&result, query))
 			assert.Equal(t, 0, len(result))
 		})
 	}

--- a/adapter/specs/insert.go
+++ b/adapter/specs/insert.go
@@ -33,7 +33,7 @@ func Insert(t *testing.T, repo rel.Repository) {
 	)
 
 	user.Addresses = nil
-	err = repo.One(&queried, where.Eq("id", user.ID))
+	err = repo.Find(&queried, where.Eq("id", user.ID))
 	assert.Nil(t, err)
 	assert.Equal(t, user, queried)
 }

--- a/adapter/specs/preload.go
+++ b/adapter/specs/preload.go
@@ -33,7 +33,7 @@ func PreloadHasMany(t *testing.T, repo rel.Repository) {
 		user   = createPreloadUser(repo)
 	)
 
-	err := repo.One(&result, where.Eq("id", user.ID))
+	err := repo.Find(&result, where.Eq("id", user.ID))
 	assert.Nil(t, err)
 
 	err = repo.Preload(&result, "addresses")
@@ -47,7 +47,7 @@ func PreloadHasManyWithQuery(t *testing.T, repo rel.Repository) {
 		user   = createPreloadUser(repo)
 	)
 
-	err := repo.One(&result, where.Eq("id", user.ID))
+	err := repo.Find(&result, where.Eq("id", user.ID))
 	assert.Nil(t, err)
 
 	err = repo.Preload(&result, "addresses", where.Eq("name", "primary"))
@@ -65,7 +65,7 @@ func PreloadHasManySlice(t *testing.T, repo rel.Repository) {
 		}
 	)
 
-	err := repo.All(&result, where.In("id", users[0].ID, users[1].ID))
+	err := repo.FindAll(&result, where.In("id", users[0].ID, users[1].ID))
 	assert.Nil(t, err)
 
 	err = repo.Preload(&result, "addresses")
@@ -79,7 +79,7 @@ func PreloadHasOne(t *testing.T, repo rel.Repository) {
 		user   = createPreloadUser(repo)
 	)
 
-	err := repo.One(&result, where.Eq("id", user.ID))
+	err := repo.Find(&result, where.Eq("id", user.ID))
 	assert.Nil(t, err)
 
 	err = repo.Preload(&result, "primary_address")
@@ -93,7 +93,7 @@ func PreloadHasOneWithQuery(t *testing.T, repo rel.Repository) {
 		user   = createPreloadUser(repo)
 	)
 
-	err := repo.One(&result, where.Eq("id", user.ID))
+	err := repo.Find(&result, where.Eq("id", user.ID))
 	assert.Nil(t, err)
 
 	err = repo.Preload(&result, "primary_address", where.Eq("name", "primary"))
@@ -110,7 +110,7 @@ func PreloadHasOneSlice(t *testing.T, repo rel.Repository) {
 		}
 	)
 
-	err := repo.All(&result, where.In("id", users[0].ID, users[1].ID))
+	err := repo.FindAll(&result, where.In("id", users[0].ID, users[1].ID))
 	assert.Nil(t, err)
 
 	err = repo.Preload(&result, "primary_address")
@@ -125,7 +125,7 @@ func PreloadBelongsTo(t *testing.T, repo rel.Repository) {
 		user   = createPreloadUser(repo)
 	)
 
-	err := repo.One(&result, where.Eq("id", user.Addresses[0].ID))
+	err := repo.Find(&result, where.Eq("id", user.Addresses[0].ID))
 	assert.Nil(t, err)
 
 	user.Addresses = nil
@@ -141,7 +141,7 @@ func PreloadBelongsToWithQuery(t *testing.T, repo rel.Repository) {
 		user   = createPreloadUser(repo)
 	)
 
-	err := repo.One(&result, where.Eq("id", user.Addresses[0].ID))
+	err := repo.Find(&result, where.Eq("id", user.Addresses[0].ID))
 	assert.Nil(t, err)
 
 	user.Addresses = nil

--- a/adapter/specs/query.go
+++ b/adapter/specs/query.go
@@ -85,7 +85,7 @@ func QueryNotFound(t *testing.T, repo rel.Repository) {
 	t.Run("NotFound", func(t *testing.T) {
 		var (
 			user User
-			err  = repo.One(&user, where.Eq("id", 0))
+			err  = repo.Find(&user, where.Eq("id", 0))
 		)
 
 		// find user error not found
@@ -95,10 +95,10 @@ func QueryNotFound(t *testing.T, repo rel.Repository) {
 
 func run(t *testing.T, repo rel.Repository, queriers []rel.Querier) {
 	for _, query := range queriers {
-		t.Run("All", func(t *testing.T) {
+		t.Run("FindAll", func(t *testing.T) {
 			var (
 				users []User
-				err   = repo.All(&users, query)
+				err   = repo.FindAll(&users, query)
 			)
 
 			assert.Nil(t, err)
@@ -107,10 +107,10 @@ func run(t *testing.T, repo rel.Repository, queriers []rel.Querier) {
 	}
 
 	for _, query := range queriers {
-		t.Run("One", func(t *testing.T) {
+		t.Run("Find", func(t *testing.T) {
 			var (
 				user User
-				err  = repo.One(&user, query)
+				err  = repo.Find(&user, query)
 			)
 
 			assert.Nil(t, err)

--- a/adapter/specs/update.go
+++ b/adapter/specs/update.go
@@ -36,7 +36,7 @@ func Update(t *testing.T, repo rel.Repository) {
 	)
 
 	user.Addresses = nil
-	err = repo.One(&queried, where.Eq("id", user.ID))
+	err = repo.Find(&queried, where.Eq("id", user.ID))
 	assert.Nil(t, err)
 	assert.Equal(t, user, queried)
 }

--- a/reltest/repository.go
+++ b/reltest/repository.go
@@ -10,6 +10,8 @@ type Repository struct {
 	mock.Mock
 }
 
+var _ rel.Repository = (*Repository)(nil)
+
 // Adapter provides a mock function with given fields:
 func (_m *Repository) Adapter() rel.Adapter {
 	ret := _m.Called()
@@ -47,8 +49,8 @@ func (_m *Repository) Aggregate(query rel.Query, aggregate string, field string)
 	return r0, r1
 }
 
-// All provides a mock function with given fields: records, queriers
-func (_m *Repository) All(records interface{}, queriers ...rel.Querier) error {
+// FindAll provides a mock function with given fields: records, queriers
+func (_m *Repository) FindAll(records interface{}, queriers ...rel.Querier) error {
 	_va := make([]interface{}, len(queriers))
 	for _i := range queriers {
 		_va[_i] = queriers[_i]
@@ -186,8 +188,8 @@ func (_m *Repository) MustAggregate(query rel.Query, aggregate string, field str
 	return r0
 }
 
-// MustAll provides a mock function with given fields: records, queriers
-func (_m *Repository) MustAll(records interface{}, queriers ...rel.Querier) {
+// MustFindAll provides a mock function with given fields: records, queriers
+func (_m *Repository) MustFindAll(records interface{}, queriers ...rel.Querier) {
 	_va := make([]interface{}, len(queriers))
 	for _i := range queriers {
 		_va[_i] = queriers[_i]
@@ -259,8 +261,8 @@ func (_m *Repository) MustInsertAll(records interface{}, changes ...rel.Changes)
 	_m.Called(_ca...)
 }
 
-// MustOne provides a mock function with given fields: record, queriers
-func (_m *Repository) MustOne(record interface{}, queriers ...rel.Querier) {
+// MustFind provides a mock function with given fields: record, queriers
+func (_m *Repository) MustFind(record interface{}, queriers ...rel.Querier) {
 	_va := make([]interface{}, len(queriers))
 	for _i := range queriers {
 		_va[_i] = queriers[_i]
@@ -307,8 +309,8 @@ func (_m *Repository) MustUpdate(record interface{}, changers ...rel.Changer) {
 	_m.Called(_ca...)
 }
 
-// One provides a mock function with given fields: record, queriers
-func (_m *Repository) One(record interface{}, queriers ...rel.Querier) error {
+// Find provides a mock function with given fields: record, queriers
+func (_m *Repository) Find(record interface{}, queriers ...rel.Querier) error {
 	_va := make([]interface{}, len(queriers))
 	for _i := range queriers {
 		_va[_i] = queriers[_i]

--- a/repository_test.go
+++ b/repository_test.go
@@ -123,7 +123,7 @@ func TestRepository_MustCount(t *testing.T) {
 	adapter.AssertExpectations(t)
 }
 
-func TestRepository_One(t *testing.T) {
+func TestRepository_Find(t *testing.T) {
 	var (
 		user    User
 		adapter = &testAdapter{}
@@ -134,7 +134,7 @@ func TestRepository_One(t *testing.T) {
 
 	adapter.On("Query", query).Return(cur, nil).Once()
 
-	assert.Nil(t, repo.One(&user, query))
+	assert.Nil(t, repo.Find(&user, query))
 	assert.Equal(t, 10, user.ID)
 	assert.False(t, cur.Next())
 
@@ -142,7 +142,7 @@ func TestRepository_One(t *testing.T) {
 	cur.AssertExpectations(t)
 }
 
-func TestRepository_One_queryError(t *testing.T) {
+func TestRepository_Find_queryError(t *testing.T) {
 	var (
 		user    User
 		adapter = &testAdapter{}
@@ -153,13 +153,13 @@ func TestRepository_One_queryError(t *testing.T) {
 
 	adapter.On("Query", query).Return(cur, errors.New("error")).Once()
 
-	assert.NotNil(t, repo.One(&user, query))
+	assert.NotNil(t, repo.Find(&user, query))
 
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)
 }
 
-func TestRepository_One_notFound(t *testing.T) {
+func TestRepository_Find_notFound(t *testing.T) {
 	var (
 		user    User
 		adapter = &testAdapter{}
@@ -170,14 +170,14 @@ func TestRepository_One_notFound(t *testing.T) {
 
 	adapter.On("Query", query).Return(cur, nil).Once()
 
-	err := repo.One(&user, query)
+	err := repo.Find(&user, query)
 	assert.Equal(t, NoResultError{}, err)
 
 	adapter.AssertExpectations(t)
 	cur.AssertExpectations(t)
 }
 
-func TestRepository_MustOne(t *testing.T) {
+func TestRepository_MustFind(t *testing.T) {
 	var (
 		user    User
 		adapter = &testAdapter{}
@@ -189,7 +189,7 @@ func TestRepository_MustOne(t *testing.T) {
 	adapter.On("Query", query).Return(cur, nil).Once()
 
 	assert.NotPanics(t, func() {
-		repo.MustOne(&user, query)
+		repo.MustFind(&user, query)
 	})
 
 	assert.Equal(t, 10, user.ID)
@@ -199,7 +199,7 @@ func TestRepository_MustOne(t *testing.T) {
 	cur.AssertExpectations(t)
 }
 
-func TestRepository_All(t *testing.T) {
+func TestRepository_FindAll(t *testing.T) {
 	var (
 		users   []User
 		adapter = &testAdapter{}
@@ -210,7 +210,7 @@ func TestRepository_All(t *testing.T) {
 
 	adapter.On("Query", query).Return(cur, nil).Once()
 
-	assert.Nil(t, repo.All(&users, query))
+	assert.Nil(t, repo.FindAll(&users, query))
 	assert.Len(t, users, 2)
 	assert.Equal(t, 10, users[0].ID)
 	assert.Equal(t, 10, users[1].ID)
@@ -219,7 +219,7 @@ func TestRepository_All(t *testing.T) {
 	cur.AssertExpectations(t)
 }
 
-func TestRepository_All_error(t *testing.T) {
+func TestRepository_FindAll_error(t *testing.T) {
 	var (
 		users   []User
 		adapter = &testAdapter{}
@@ -230,12 +230,12 @@ func TestRepository_All_error(t *testing.T) {
 
 	adapter.On("Query", query).Return(&testCursor{}, err).Once()
 
-	assert.Equal(t, err, repo.All(&users, query))
+	assert.Equal(t, err, repo.FindAll(&users, query))
 
 	adapter.AssertExpectations(t)
 }
 
-func TestRepository_MustAll(t *testing.T) {
+func TestRepository_MustFindAll(t *testing.T) {
 	var (
 		users   []User
 		adapter = &testAdapter{}
@@ -247,7 +247,7 @@ func TestRepository_MustAll(t *testing.T) {
 	adapter.On("Query", query).Return(cur, nil).Once()
 
 	assert.NotPanics(t, func() {
-		repo.MustAll(&users, query)
+		repo.MustFindAll(&users, query)
 	})
 
 	assert.Len(t, users, 2)


### PR DESCRIPTION
Renamed:
- `One` -> `Find`
- `All` -> `FindAll`

It's provide more consistent naming with other methods such as Update and UpdateAll.