### PR TITLE
More Consistent Assoc Definition

### DIFF
--- a/document.go
+++ b/document.go
@@ -318,6 +318,7 @@ func extractDocumentData(rt reflect.Type, skipAssoc bool) documentData {
 		}
 	)
 
+	// TODO probably better to use slice index instead.
 	for i := 0; i < rt.NumField(); i++ {
 		var (
 			sf   = rt.Field(i)

--- a/document.go
+++ b/document.go
@@ -303,12 +303,12 @@ func newDocument(v interface{}, rv reflect.Value, readonly bool) *Document {
 		v:    v,
 		rv:   rv,
 		rt:   rt,
-		data: extractdocumentData(rv, rt),
+		data: extractDocumentData(rt, false),
 	}
 }
 
-func extractdocumentData(rv reflect.Value, rt reflect.Type) documentData {
-	if data, cached := documentDataCache.Load(rv.Type()); cached {
+func extractDocumentData(rt reflect.Type, skipAssoc bool) documentData {
+	if data, cached := documentDataCache.Load(rt); cached {
 		return data.(documentData)
 	}
 
@@ -347,17 +347,21 @@ func extractdocumentData(rv reflect.Value, rt reflect.Type) documentData {
 			continue
 		}
 
-		switch newAssociation(rv, i).Type() {
-		case BelongsTo:
-			data.belongsTo = append(data.belongsTo, name)
-		case HasOne:
-			data.hasOne = append(data.hasOne, name)
-		case HasMany:
-			data.hasMany = append(data.hasMany, name)
+		if !skipAssoc {
+			switch extractAssociationData(rt, i).typ {
+			case BelongsTo:
+				data.belongsTo = append(data.belongsTo, name)
+			case HasOne:
+				data.hasOne = append(data.hasOne, name)
+			case HasMany:
+				data.hasMany = append(data.hasMany, name)
+			}
 		}
 	}
 
-	documentDataCache.Store(rt, data)
+	if !skipAssoc {
+		documentDataCache.Store(rt, data)
+	}
 
 	return data
 }

--- a/rel_test.go
+++ b/rel_test.go
@@ -10,7 +10,7 @@ type User struct {
 	ID           int
 	Name         string
 	Age          int
-	Transactions []Transaction `references:"ID" foreign_key:"BuyerID"`
+	Transactions []Transaction `ref:"id" fk:"user_id"`
 	Address      Address
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
@@ -21,7 +21,7 @@ type Transaction struct {
 	Item    string
 	Status  Status
 	BuyerID int  `db:"user_id"`
-	Buyer   User `references:"BuyerID" foreign_key:"ID"`
+	Buyer   User `ref:"user_id" fk:"id"`
 }
 
 type Address struct {


### PR DESCRIPTION
- Use db field name instead of struct field name to manually define assoc fields.
- struct tag: `references` renamed to `ref`.
- struct tag: `foreign_key` renamed to `fk`.
- struct tag: removed `association`.