### PR TITLE
save zero value when creating and updating with struct

### DIFF
--- a/adapter/mysql/mysql_test.go
+++ b/adapter/mysql/mysql_test.go
@@ -105,6 +105,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.UpdateHasOneUpdate(t, repo)
 	specs.UpdateBelongsToInsert(t, repo)
 	specs.UpdateBelongsToUpdate(t, repo)
+	specs.UpdateAtomic(t, repo)
 	specs.Updates(t, repo)
 
 	// Delete specs

--- a/adapter/postgres/postgres_test.go
+++ b/adapter/postgres/postgres_test.go
@@ -105,6 +105,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.UpdateHasOneUpdate(t, repo)
 	specs.UpdateBelongsToInsert(t, repo)
 	specs.UpdateBelongsToUpdate(t, repo)
+	specs.UpdateAtomic(t, repo)
 	specs.Updates(t, repo)
 
 	// Delete specs

--- a/adapter/specs/constraint.go
+++ b/adapter/specs/constraint.go
@@ -8,11 +8,14 @@ import (
 
 // UniqueConstraint tests unique constraint specifications.
 func UniqueConstraint(t *testing.T, repo rel.Repository) {
+	var user User
+	repo.MustInsert(&user)
+
 	var (
 		slug1  = "slug1"
 		slug2  = "slug2"
-		extra1 = Extra{Slug: &slug1}
-		extra2 = Extra{Slug: &slug2}
+		extra1 = Extra{Slug: &slug1, UserID: user.ID}
+		extra2 = Extra{Slug: &slug2, UserID: user.ID}
 	)
 
 	repo.MustInsert(&extra1)
@@ -51,8 +54,11 @@ func ForeignKeyConstraint(t *testing.T, repo rel.Repository) {
 
 // CheckConstraint tests foreign key constraint specifications.
 func CheckConstraint(t *testing.T, repo rel.Repository) {
+	var user User
+	repo.MustInsert(&user)
+
 	var (
-		extra Extra
+		extra = Extra{UserID: user.ID}
 	)
 
 	repo.MustInsert(&extra)

--- a/adapter/specs/constraint.go
+++ b/adapter/specs/constraint.go
@@ -6,20 +6,21 @@ import (
 	"github.com/Fs02/rel"
 )
 
-// UniqueConstraint tests unique constraint specifications.
-func UniqueConstraint(t *testing.T, repo rel.Repository) {
+func createExtra(repo rel.Repository, slug string) Extra {
 	var user User
 	repo.MustInsert(&user)
 
-	var (
-		slug1  = "slug1"
-		slug2  = "slug2"
-		extra1 = Extra{Slug: &slug1, UserID: user.ID}
-		extra2 = Extra{Slug: &slug2, UserID: user.ID}
-	)
+	extra := Extra{Slug: &slug, UserID: user.ID}
+	repo.MustInsert(&extra)
+	return extra
+}
 
-	repo.MustInsert(&extra1)
-	repo.MustInsert(&extra2)
+// UniqueConstraint tests unique constraint specifications.
+func UniqueConstraint(t *testing.T, repo rel.Repository) {
+	var (
+		extra1 = createExtra(repo, "unique-slug1")
+		extra2 = createExtra(repo, "unique-slug2")
+	)
 
 	t.Run("UniqueConstraint", func(t *testing.T) {
 		// inserting
@@ -34,11 +35,9 @@ func UniqueConstraint(t *testing.T, repo rel.Repository) {
 
 // ForeignKeyConstraint tests foreign key constraint specifications.
 func ForeignKeyConstraint(t *testing.T, repo rel.Repository) {
-	var user User
-	repo.MustInsert(&user)
-
-	extra := Extra{UserID: user.ID}
-	repo.MustInsert(&extra)
+	var (
+		extra = createExtra(repo, "fk-slug")
+	)
 
 	t.Run("ForeignKeyConstraint", func(t *testing.T) {
 		// inserting
@@ -54,11 +53,9 @@ func ForeignKeyConstraint(t *testing.T, repo rel.Repository) {
 
 // CheckConstraint tests foreign key constraint specifications.
 func CheckConstraint(t *testing.T, repo rel.Repository) {
-	var user User
-	repo.MustInsert(&user)
-
-	extra := Extra{UserID: user.ID}
-	repo.MustInsert(&extra)
+	var (
+		extra = createExtra(repo, "check-slug")
+	)
 
 	t.Run("CheckConstraint", func(t *testing.T) {
 		// inserting

--- a/adapter/specs/constraint.go
+++ b/adapter/specs/constraint.go
@@ -34,10 +34,10 @@ func UniqueConstraint(t *testing.T, repo rel.Repository) {
 
 // ForeignKeyConstraint tests foreign key constraint specifications.
 func ForeignKeyConstraint(t *testing.T, repo rel.Repository) {
-	var (
-		extra Extra
-	)
+	var user User
+	repo.MustInsert(&user)
 
+	extra := Extra{UserID: user.ID}
 	repo.MustInsert(&extra)
 
 	t.Run("ForeignKeyConstraint", func(t *testing.T) {
@@ -57,10 +57,7 @@ func CheckConstraint(t *testing.T, repo rel.Repository) {
 	var user User
 	repo.MustInsert(&user)
 
-	var (
-		extra = Extra{UserID: user.ID}
-	)
-
+	extra := Extra{UserID: user.ID}
 	repo.MustInsert(&extra)
 
 	t.Run("CheckConstraint", func(t *testing.T) {

--- a/adapter/specs/insert.go
+++ b/adapter/specs/insert.go
@@ -158,7 +158,7 @@ func Inserts(t *testing.T, repo rel.Repository) {
 
 	for _, record := range tests {
 		var (
-			changes      = rel.BuildChanges(rel.NewStructset(record))
+			changes      = rel.BuildChanges(rel.NewStructset(record, false))
 			statement, _ = builder.Insert("collection", changes)
 		)
 

--- a/adapter/specs/specs.go
+++ b/adapter/specs/specs.go
@@ -39,7 +39,7 @@ type Extra struct {
 	ID     uint
 	Slug   *string
 	Score  int
-	UserID int
+	UserID int64
 }
 
 var (

--- a/adapter/specs/update.go
+++ b/adapter/specs/update.go
@@ -334,7 +334,7 @@ func Updates(t *testing.T, repo rel.Repository) {
 
 	for _, record := range tests {
 		var (
-			changes      = rel.BuildChanges(rel.NewStructset(record))
+			changes      = rel.BuildChanges(rel.NewStructset(record, false))
 			statement, _ = builder.Update("collection", changes, where.Eq("id", 1))
 		)
 

--- a/adapter/sqlite3/sqlite3_test.go
+++ b/adapter/sqlite3/sqlite3_test.go
@@ -108,6 +108,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.UpdateHasOneUpdate(t, repo)
 	specs.UpdateBelongsToInsert(t, repo)
 	specs.UpdateBelongsToUpdate(t, repo)
+	specs.UpdateAtomic(t, repo)
 	specs.Updates(t, repo)
 
 	// Delete specs

--- a/docs/crud.md
+++ b/docs/crud.md
@@ -196,7 +196,7 @@ repo.ExpectFindAll(query).Result(books)
 
 Similar to create, updating a record in rel can also be done using struct, map or set function. Updating using struct will also update `updated_at` field if any.
 
-> An update using struct will cause all fields to be saved to database, regardless of whether it's been updated or not. Use `rel.Map` or `rel.Set` to update only specified fields.
+> An update using struct will cause all fields to be saved to database, regardless of whether it's been updated or not. Use `rel.Map`, `rel.Set` or `rel.Structset` to update only specified fields.
 
 <!-- tabs:start -->
 

--- a/reltest/modify.go
+++ b/reltest/modify.go
@@ -48,7 +48,7 @@ func ExpectModify(r *Repository, methodName string, changers []rel.Changer, inse
 		)
 
 		if len(changers) == 0 {
-			changes = rel.BuildChanges(rel.NewStructset(args[0]))
+			changes = rel.BuildChanges(rel.NewStructset(args[0], false))
 		} else {
 			changes = rel.BuildChanges(changers...)
 		}

--- a/repository.go
+++ b/repository.go
@@ -148,7 +148,7 @@ func (r repository) Insert(record interface{}, changers ...Changer) error {
 	)
 
 	if len(changers) == 0 {
-		changes = BuildChanges(newStructset(doc))
+		changes = BuildChanges(newStructset(doc, false))
 	} else {
 		changes = BuildChanges(changers...)
 	}
@@ -211,7 +211,7 @@ func (r repository) InsertAll(records interface{}, changes ...Changes) error {
 	if len(changes) == 0 {
 		changes = make([]Changes, col.Len())
 		for i := range changes {
-			changes[i] = BuildChanges(newStructset(col.Get(i)))
+			changes[i] = BuildChanges(newStructset(col.Get(i), false))
 		}
 	}
 
@@ -274,7 +274,7 @@ func (r repository) Update(record interface{}, changers ...Changer) error {
 	)
 
 	if len(changers) == 0 {
-		changes = BuildChanges(newStructset(doc))
+		changes = BuildChanges(newStructset(doc, false))
 	} else {
 		changes = BuildChanges(changers...)
 	}

--- a/repository_test.go
+++ b/repository_test.go
@@ -370,7 +370,7 @@ func TestRepository_Insert_saveHasManyError(t *testing.T) {
 	adapter.On("Begin").Return(nil).Once()
 	adapter.On("Insert", From("users"), mock.Anything).Return(1, nil).Once()
 	adapter.On("Query", From("users").Where(Eq("id", 1)).Limit(1)).Return(cur, nil).Once()
-	adapter.On("InsertAll", From("transactions"), []string{"item", "user_id"}, mock.Anything).Return([]interface{}{}, err).Once()
+	adapter.On("InsertAll", From("transactions"), []string{"item", "status", "user_id"}, mock.Anything).Return([]interface{}{}, err).Once()
 	adapter.On("Rollback").Return(nil).Once()
 
 	assert.Equal(t, err, repo.Insert(&user))
@@ -438,18 +438,20 @@ func TestRepository_InsertAll_collection(t *testing.T) {
 	var (
 		users = []User{
 			{Name: "name1"},
-			{Name: "name2"},
+			{Name: "name2", Age: 12},
 		}
 		adapter = &testAdapter{}
 		repo    = repository{adapter: adapter}
 		changes = []Changes{
 			BuildChanges(
 				Set("name", "name1"),
+				Set("age", 0),
 				Set("created_at", now()),
 				Set("updated_at", now()),
 			),
 			BuildChanges(
 				Set("name", "name2"),
+				Set("age", 12),
 				Set("created_at", now()),
 				Set("updated_at", now()),
 			),
@@ -457,7 +459,7 @@ func TestRepository_InsertAll_collection(t *testing.T) {
 		cur = createCursor(2)
 	)
 
-	adapter.On("InsertAll", From("users"), []string{"name", "created_at", "updated_at"}, changes).Return([]interface{}{1, 2}, nil).Once()
+	adapter.On("InsertAll", From("users"), []string{"name", "age", "created_at", "updated_at"}, changes).Return([]interface{}{1, 2}, nil).Once()
 	adapter.On("Query", From("users").Where(In("id", 1, 2))).Return(cur, nil).Once()
 
 	assert.Nil(t, repo.InsertAll(&users))


### PR DESCRIPTION
- Previously, zero field's value will be ignored when creating or updating struct and will be saved as `null` in the database.
- Now every fields will be saved regardless of it's value.
- To save only specified field, rel.NewStructset(structs, true) may be used.
- The reason for this to makes it more consistent when querying field. example we have a struct with `published bool` field. and we want to be able to query with published=true or published=false. previously it's not possible, and instead we need to query as published=true and `published is nil`, since false is a zero value and always be saved as nil