### PR TITLE
Raw SQL Query Builder.

### DIFF
--- a/adapter/specs/query.go
+++ b/adapter/specs/query.go
@@ -61,8 +61,8 @@ func Query(t *testing.T, repo rel.Repository) {
 		rel.Select("name").Where(where.Eq("id", 1)),
 		rel.Select("name", "age").Where(where.Eq("id", 1)),
 		rel.Select().Distinct().Where(where.Eq("id", 1)),
-		rel.SQL("SELECT 1+?", 2),
-		rel.SQL("SELECT 1+?;", 2),
+		rel.SQL("SELECT 1"),
+		rel.SQL("SELECT 1;"),
 	}
 
 	run(t, repo, tests)

--- a/adapter/specs/query.go
+++ b/adapter/specs/query.go
@@ -61,6 +61,8 @@ func Query(t *testing.T, repo rel.Repository) {
 		rel.Select("name").Where(where.Eq("id", 1)),
 		rel.Select("name", "age").Where(where.Eq("id", 1)),
 		rel.Select().Distinct().Where(where.Eq("id", 1)),
+		rel.SQL("SELECT 1+?", 2),
+		rel.SQL("SELECT 1+?;", 2),
 	}
 
 	run(t, repo, tests)

--- a/adapter/sql/builder.go
+++ b/adapter/sql/builder.go
@@ -22,6 +22,10 @@ type Builder struct {
 
 // Find generates query for select.
 func (b *Builder) Find(query rel.Query) (string, []interface{}) {
+	if query.SQLQuery.Statement != "" {
+		return query.SQLQuery.Statement, query.SQLQuery.Values
+	}
+
 	var (
 		buffer Buffer
 	)

--- a/adapter/sql/builder_test.go
+++ b/adapter/sql/builder_test.go
@@ -197,6 +197,18 @@ func TestBuilder_Find_ordinal(t *testing.T) {
 	}
 }
 
+func TestBuilder_Find_SQLQuery(t *testing.T) {
+	var (
+		config   = &Config{}
+		builder  = NewBuilder(config)
+		query    = rel.Build("", rel.SQL("SELECT * FROM `users` WHERE id=?;", 1))
+		qs, args = builder.Find(query)
+	)
+
+	assert.Equal(t, "SELECT * FROM `users` WHERE id=?;", qs)
+	assert.Equal(t, []interface{}{1}, args)
+}
+
 func BenchmarkBuilder_Aggregate(b *testing.B) {
 	var (
 		config = &Config{

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -24,6 +24,7 @@
     * [Aggregation](query.md#aggregation)
     * [Pagination](query.md#pagination)
     * [Batch Iteration](query.md#batch-iteration)
+    * [Native SQL Query](query.md#native-sql-query)
 
 * [Association](association.md)
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
   <script>
     window.$docsify = {
       name: 'REL',
-      ga: 'UA-118567391-2',
+      // ga: 'UA-118567391-2',
       repo: 'https://github.com/Fs02/rel',
       auto2top: true,
       themeColor: '#007d9c',

--- a/docs/index.html
+++ b/docs/index.html
@@ -37,7 +37,7 @@
   <script>
     window.$docsify = {
       name: 'REL',
-      // ga: 'UA-118567391-2',
+      ga: 'UA-118567391-2',
       repo: 'https://github.com/Fs02/rel',
       auto2top: true,
       themeColor: '#007d9c',

--- a/docs/query.go
+++ b/docs/query.go
@@ -10,8 +10,8 @@ import (
 	"github.com/Fs02/rel/where"
 )
 
-// Find docs example.
-func Find(ctx context.Context, repo rel.Repository) error {
+// QueryFind docs example.
+func QueryFind(ctx context.Context, repo rel.Repository) error {
 	/// [find]
 	var book Book
 	err := repo.Find(ctx, &book, where.Eq("id", 1))
@@ -20,8 +20,8 @@ func Find(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// FindAll docs example.
-func FindAll(ctx context.Context, repo rel.Repository) error {
+// QueryFindAll docs example.
+func QueryFindAll(ctx context.Context, repo rel.Repository) error {
 	/// [find-all]
 	var books []Book
 	err := repo.FindAll(ctx, &books)
@@ -30,8 +30,8 @@ func FindAll(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// Condition docs example.
-func Condition(ctx context.Context, repo rel.Repository) error {
+// QueryCondition docs example.
+func QueryCondition(ctx context.Context, repo rel.Repository) error {
 	/// [condition]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.Eq("available", true))
@@ -40,8 +40,8 @@ func Condition(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// ConditionAlias docs example.
-func ConditionAlias(ctx context.Context, repo rel.Repository) error {
+// QueryConditionAlias docs example.
+func QueryConditionAlias(ctx context.Context, repo rel.Repository) error {
 	/// [condition-alias]
 	var books []Book
 	err := repo.FindAll(ctx, &books, where.Eq("available", true))
@@ -50,8 +50,8 @@ func ConditionAlias(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// ConditionFragment docs example.
-func ConditionFragment(ctx context.Context, repo rel.Repository) error {
+// QueryConditionFragment docs example.
+func QueryConditionFragment(ctx context.Context, repo rel.Repository) error {
 	/// [condition-fragment]
 	var books []Book
 	err := repo.FindAll(ctx, &books, where.Fragment("available=?", true))
@@ -60,8 +60,8 @@ func ConditionFragment(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// ConditionAdvanced docs example.
-func ConditionAdvanced(ctx context.Context, repo rel.Repository) error {
+// QueryConditionAdvanced docs example.
+func QueryConditionAdvanced(ctx context.Context, repo rel.Repository) error {
 	/// [condition-advanced]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.And(rel.Eq("available", true), rel.Or(rel.Gte("price", 100), rel.Eq("discount", true))))
@@ -70,8 +70,8 @@ func ConditionAdvanced(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// ConditionAdvancedChain docs example.
-func ConditionAdvancedChain(ctx context.Context, repo rel.Repository) error {
+// QueryConditionAdvancedChain docs example.
+func QueryConditionAdvancedChain(ctx context.Context, repo rel.Repository) error {
 	/// [condition-advanced-chain]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.Eq("available", true).And(rel.Gte("price", 100).OrEq("discount", true)))
@@ -80,8 +80,8 @@ func ConditionAdvancedChain(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// ConditionAdvancedAlias docs example.
-func ConditionAdvancedAlias(ctx context.Context, repo rel.Repository) error {
+// QueryConditionAdvancedAlias docs example.
+func QueryConditionAdvancedAlias(ctx context.Context, repo rel.Repository) error {
 	/// [condition-advanced-alias]
 	var books []Book
 	err := repo.FindAll(ctx, &books, where.Eq("available", true).And(where.Gte("price", 100).OrEq("discount", true)))
@@ -90,8 +90,8 @@ func ConditionAdvancedAlias(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// Sorting docs example.
-func Sorting(ctx context.Context, repo rel.Repository) error {
+// QuerySorting docs example.
+func QuerySorting(ctx context.Context, repo rel.Repository) error {
 	/// [sorting]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.NewSortAsc("updated_at"))
@@ -100,8 +100,8 @@ func Sorting(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// SortingAlias docs example.
-func SortingAlias(ctx context.Context, repo rel.Repository) error {
+// QuerySortingAlias docs example.
+func QuerySortingAlias(ctx context.Context, repo rel.Repository) error {
 	/// [sorting-alias]
 	var books []Book
 	err := repo.FindAll(ctx, &books, sort.Asc("updated_at"))
@@ -110,8 +110,8 @@ func SortingAlias(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// SortingWithCondition docs example.
-func SortingWithCondition(ctx context.Context, repo rel.Repository) error {
+// QuerySortingWithCondition docs example.
+func QuerySortingWithCondition(ctx context.Context, repo rel.Repository) error {
 	/// [sorting-with-condition]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.Where(where.Eq("available", true)).SortAsc("updated_at"))
@@ -120,8 +120,8 @@ func SortingWithCondition(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// SortingWithConditionVariadic docs example.
-func SortingWithConditionVariadic(ctx context.Context, repo rel.Repository) error {
+// QuerySortingWithConditionVariadic docs example.
+func QuerySortingWithConditionVariadic(ctx context.Context, repo rel.Repository) error {
 	/// [sorting-with-condition-variadic]
 	var books []Book
 	err := repo.FindAll(ctx, &books, where.Eq("available", true), sort.Asc("updated_at"))
@@ -130,8 +130,8 @@ func SortingWithConditionVariadic(ctx context.Context, repo rel.Repository) erro
 	return err
 }
 
-// Select docs example.
-func Select(ctx context.Context, repo rel.Repository) error {
+// QuerySelect docs example.
+func QuerySelect(ctx context.Context, repo rel.Repository) error {
 	/// [select]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.Select("id", "title"))
@@ -140,8 +140,8 @@ func Select(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// Table docs example.
-func Table(ctx context.Context, repo rel.Repository) error {
+// QueryTable docs example.
+func QueryTable(ctx context.Context, repo rel.Repository) error {
 	/// [table]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.From("ebooks"))
@@ -150,8 +150,8 @@ func Table(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// TableChained docs example.
-func TableChained(ctx context.Context, repo rel.Repository) error {
+// QueryTableChained docs example.
+func QueryTableChained(ctx context.Context, repo rel.Repository) error {
 	/// [table-chained]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.Select("id", "title").From("ebooks"))
@@ -160,8 +160,8 @@ func TableChained(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// LimitOffset docs example.
-func LimitOffset(ctx context.Context, repo rel.Repository) error {
+// QueryLimitOffset docs example.
+func QueryLimitOffset(ctx context.Context, repo rel.Repository) error {
 	/// [limit-offset]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.Limit(10), rel.Offset(20))
@@ -170,8 +170,8 @@ func LimitOffset(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// LimitOffsetChained docs example.
-func LimitOffsetChained(ctx context.Context, repo rel.Repository) error {
+// QueryLimitOffsetChained docs example.
+func QueryLimitOffsetChained(ctx context.Context, repo rel.Repository) error {
 	/// [limit-offset-chained]
 	var books []Book
 	err := repo.FindAll(ctx, &books, rel.Select().Limit(10).Offset(20))
@@ -180,8 +180,8 @@ func LimitOffsetChained(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// Group docs example.
-func Group(ctx context.Context, repo rel.Repository) error {
+// QueryGroup docs example.
+func QueryGroup(ctx context.Context, repo rel.Repository) error {
 	/// [group]
 	// custom struct to store the result.
 	var results []struct {
@@ -196,8 +196,8 @@ func Group(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// Join docs example.
-func Join(ctx context.Context, repo rel.Repository) error {
+// QueryJoin docs example.
+func QueryJoin(ctx context.Context, repo rel.Repository) error {
 	/// [join]
 	var transactions []Transaction
 	err := repo.FindAll(ctx, &transactions, rel.Join("books").Where(where.Eq("books.name", "REL for Dummies")))
@@ -206,8 +206,8 @@ func Join(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// JoinOn docs example.
-func JoinOn(ctx context.Context, repo rel.Repository) error {
+// QueryJoinOn docs example.
+func QueryJoinOn(ctx context.Context, repo rel.Repository) error {
 	/// [join-on]
 	var transactions []Transaction
 	err := repo.FindAll(ctx, &transactions, rel.JoinOn("books", "transactions.book_id", "books.id"))
@@ -216,8 +216,8 @@ func JoinOn(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// JoinAlias docs example.
-func JoinAlias(ctx context.Context, repo rel.Repository) error {
+// QueryJoinAlias docs example.
+func QueryJoinAlias(ctx context.Context, repo rel.Repository) error {
 	/// [join-alias]
 	var transactions []Transaction
 	err := repo.FindAll(ctx, &transactions, join.On("books", "transactions.book_id", "books.id"))
@@ -226,8 +226,8 @@ func JoinAlias(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// JoinWith docs example.
-func JoinWith(ctx context.Context, repo rel.Repository) error {
+// QueryJoinWith docs example.
+func QueryJoinWith(ctx context.Context, repo rel.Repository) error {
 	/// [join-with]
 	var transactions []Transaction
 	err := repo.FindAll(ctx, &transactions, rel.JoinWith("LEFT JOIN", "books", "transactions.book_id", "books.id"))
@@ -236,8 +236,8 @@ func JoinWith(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// JoinFragment docs example.
-func JoinFragment(ctx context.Context, repo rel.Repository) error {
+// QueryJoinFragment docs example.
+func QueryJoinFragment(ctx context.Context, repo rel.Repository) error {
 	/// [join-fragment]
 	var transactions []Transaction
 	err := repo.FindAll(ctx, &transactions, rel.Joinf("JOIN `books` ON `transactions`.`book_id`=`books`.`id`"))
@@ -246,8 +246,8 @@ func JoinFragment(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// Lock docs example.
-func Lock(ctx context.Context, repo rel.Repository) error {
+// QueryLock docs example.
+func QueryLock(ctx context.Context, repo rel.Repository) error {
 	/// [lock]
 	var book Book
 	err := repo.Find(ctx, &book, where.Eq("id", 1), rel.Lock("FOR UPDATE"))
@@ -256,8 +256,8 @@ func Lock(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// LockForUpdate docs example.
-func LockForUpdate(ctx context.Context, repo rel.Repository) error {
+// QueryLockForUpdate docs example.
+func QueryLockForUpdate(ctx context.Context, repo rel.Repository) error {
 	/// [lock-for-update]
 	var book Book
 	err := repo.Find(ctx, &book, where.Eq("id", 1), rel.ForUpdate())
@@ -266,8 +266,8 @@ func LockForUpdate(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// LockChained docs example.
-func LockChained(ctx context.Context, repo rel.Repository) error {
+// QueryLockChained docs example.
+func QueryLockChained(ctx context.Context, repo rel.Repository) error {
 	/// [lock-chained]
 	var book Book
 	err := repo.Find(ctx, &book, rel.Where(where.Eq("id", 1)).Lock("FOR UPDATE"))
@@ -276,8 +276,8 @@ func LockChained(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// Aggregate docs example.
-func Aggregate(ctx context.Context, repo rel.Repository) error {
+// QueryAggregate docs example.
+func QueryAggregate(ctx context.Context, repo rel.Repository) error {
 	/// [aggregate]
 	count, err := repo.Aggregate(ctx, rel.From("books").Where(where.Eq("available", true)), "count", "id")
 	/// [aggregate]
@@ -286,8 +286,8 @@ func Aggregate(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// Count docs example.
-func Count(ctx context.Context, repo rel.Repository) error {
+// QueryCount docs example.
+func QueryCount(ctx context.Context, repo rel.Repository) error {
 	/// [count]
 	count, err := repo.Count(ctx, "books")
 	/// [count]
@@ -296,8 +296,8 @@ func Count(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// CountWithCondition docs example.
-func CountWithCondition(ctx context.Context, repo rel.Repository) error {
+// QueryCountWithCondition docs example.
+func QueryCountWithCondition(ctx context.Context, repo rel.Repository) error {
 	/// [count-with-condition]
 	count, err := repo.Count(ctx, "books", where.Eq("available", true))
 	/// [count-with-condition]
@@ -306,8 +306,8 @@ func CountWithCondition(ctx context.Context, repo rel.Repository) error {
 	return err
 }
 
-// FindAndCountAll docs example.
-func FindAndCountAll(ctx context.Context, repo rel.Repository) error {
+// QueryFindAndCountAll docs example.
+func QueryFindAndCountAll(ctx context.Context, repo rel.Repository) error {
 	/// [find-and-count-all]
 	var books []Book
 	count, err := repo.FindAndCountAll(ctx, &books, rel.Where(where.Like("title", "%dummies%")).Limit(10).Offset(10))
@@ -320,8 +320,8 @@ func FindAndCountAll(ctx context.Context, repo rel.Repository) error {
 // SendPromotionEmail tp demonstrate Iteration.
 func SendPromotionEmail(*User) {}
 
-// Iteration docs example.
-func Iteration(ctx context.Context, repo rel.Repository) error {
+// QueryIteration docs example.
+func QueryIteration(ctx context.Context, repo rel.Repository) error {
 	/// [batch-iteration]
 	var (
 		user User
@@ -347,4 +347,15 @@ func Iteration(ctx context.Context, repo rel.Repository) error {
 	/// [batch-iteration]
 
 	return nil
+}
+
+// QuerySQL natively.
+func QuerySQL(ctx context.Context, repo rel.Repository) error {
+	/// [sql]
+	var book Book
+	sql := rel.SQL("SELECT id, title, price, orders = (SELECT COUNT(t.id) FROM [transactions] t WHERE t.book_id = b.id) FROM books b where b.id=?", 1)
+	err := repo.Find(ctx, &book, sql)
+	/// [sql]
+
+	return err
 }

--- a/docs/query.md
+++ b/docs/query.md
@@ -441,7 +441,7 @@ Mock and retuns `reltest.ErrConnectionClosed` (`sql.ErrConnDone`).
 
 ## Native SQL Query
 
-REL allows querying using native SQL query, this is especially usefull when using complex query that cannot be covered with the query builder.
+REL allows querying using native SQL query, this is especially useful when using complex query that cannot be covered with the query builder.
 
 <!-- tabs:start -->
 

--- a/docs/query.md
+++ b/docs/query.md
@@ -439,4 +439,24 @@ Mock and retuns `reltest.ErrConnectionClosed` (`sql.ErrConnDone`).
 
 <!-- tabs:end -->
 
+## Native SQL Query
+
+REL allows querying using native SQL query, this is especially usefull when using complex query that cannot be covered with the query builder.
+
+<!-- tabs:start -->
+
+### **Example**
+
+Retrieve a book using raw sql query.
+
+[query.go](query.go ':include :fragment=sql')
+
+### **Mock**
+
+Mock and retrieve a book using raw sql query.
+
+[query_test.go](query_test.go ':include :fragment=sql')
+
+<!-- tabs:end -->
+
 **Next: [Association](association.md)**

--- a/docs/query.md
+++ b/docs/query.md
@@ -447,13 +447,13 @@ REL allows querying using native SQL query, this is especially useful when using
 
 ### **Example**
 
-Retrieve a book using raw sql query.
+Retrieve a book using native sql query.
 
 [query.go](query.go ':include :fragment=sql')
 
 ### **Mock**
 
-Mock and retrieve a book using raw sql query.
+Mock and retrieve a book using native sql query.
 
 [query_test.go](query_test.go ':include :fragment=sql')
 

--- a/docs/query_test.go
+++ b/docs/query_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestFind(t *testing.T) {
+func TestQueryFind(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -24,11 +24,11 @@ func TestFind(t *testing.T) {
 	repo.ExpectFind(where.Eq("id", 1)).Result(book)
 	/// [find]
 
-	assert.Nil(t, Find(ctx, repo))
+	assert.Nil(t, QueryFind(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestFindAll(t *testing.T) {
+func TestQueryFindAll(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -41,11 +41,11 @@ func TestFindAll(t *testing.T) {
 	repo.ExpectFindAll().Result(books)
 	/// [find-all]
 
-	assert.Nil(t, FindAll(ctx, repo))
+	assert.Nil(t, QueryFindAll(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestCondition(t *testing.T) {
+func TestQueryCondition(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -58,11 +58,11 @@ func TestCondition(t *testing.T) {
 	repo.ExpectFindAll(rel.Eq("available", true)).Result(books)
 	/// [condition]
 
-	assert.Nil(t, Condition(ctx, repo))
+	assert.Nil(t, QueryCondition(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestConditionAlias(t *testing.T) {
+func TestQueryConditionAlias(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -75,11 +75,11 @@ func TestConditionAlias(t *testing.T) {
 	repo.ExpectFindAll(where.Eq("available", true)).Result(books)
 	/// [condition-alias]
 
-	assert.Nil(t, ConditionAlias(ctx, repo))
+	assert.Nil(t, QueryConditionAlias(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestConditionFragment(t *testing.T) {
+func TestQueryConditionFragment(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -92,11 +92,11 @@ func TestConditionFragment(t *testing.T) {
 	repo.ExpectFindAll(where.Fragment("available=?", true)).Result(books)
 	/// [condition-fragment]
 
-	assert.Nil(t, ConditionFragment(ctx, repo))
+	assert.Nil(t, QueryConditionFragment(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestConditionAdvanced(t *testing.T) {
+func TestQueryConditionAdvanced(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -110,11 +110,11 @@ func TestConditionAdvanced(t *testing.T) {
 	repo.ExpectFindAll(rel.And(rel.Eq("available", true), rel.Or(rel.Gte("price", 100), rel.Eq("discount", true)))).Result(books)
 	/// [condition-advanced]
 
-	assert.Nil(t, ConditionAdvanced(ctx, repo))
+	assert.Nil(t, QueryConditionAdvanced(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestConditionAdvancedChain(t *testing.T) {
+func TestQueryConditionAdvancedChain(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -128,11 +128,11 @@ func TestConditionAdvancedChain(t *testing.T) {
 	repo.ExpectFindAll(rel.Eq("available", true).And(rel.Gte("price", 100).OrEq("discount", true))).Result(books)
 	/// [condition-advanced-chain]
 
-	assert.Nil(t, ConditionAdvancedChain(ctx, repo))
+	assert.Nil(t, QueryConditionAdvancedChain(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestConditionAdvancedAlias(t *testing.T) {
+func TestQueryConditionAdvancedAlias(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -146,11 +146,11 @@ func TestConditionAdvancedAlias(t *testing.T) {
 	repo.ExpectFindAll(where.Eq("available", true).And(where.Gte("price", 100).OrEq("discount", true))).Result(books)
 	/// [condition-advanced-alias]
 
-	assert.Nil(t, ConditionAdvancedAlias(ctx, repo))
+	assert.Nil(t, QueryConditionAdvancedAlias(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestSorting(t *testing.T) {
+func TestQuerySorting(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -163,11 +163,11 @@ func TestSorting(t *testing.T) {
 	repo.ExpectFindAll(rel.NewSortAsc("updated_at")).Result(books)
 	/// [sorting]
 
-	assert.Nil(t, Sorting(ctx, repo))
+	assert.Nil(t, QuerySorting(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestSortingAlias(t *testing.T) {
+func TestQuerySortingAlias(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -180,11 +180,11 @@ func TestSortingAlias(t *testing.T) {
 	repo.ExpectFindAll(sort.Asc("updated_at")).Result(books)
 	/// [sorting-alias]
 
-	assert.Nil(t, SortingAlias(ctx, repo))
+	assert.Nil(t, QuerySortingAlias(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestSortingWithCondition(t *testing.T) {
+func TestQuerySortingWithCondition(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -197,11 +197,11 @@ func TestSortingWithCondition(t *testing.T) {
 	repo.ExpectFindAll(rel.Where(where.Eq("available", true)).SortAsc("updated_at")).Result(books)
 	/// [sorting-with-condition]
 
-	assert.Nil(t, SortingWithCondition(ctx, repo))
+	assert.Nil(t, QuerySortingWithCondition(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestSortingWithConditionVariadic(t *testing.T) {
+func TestQuerySortingWithConditionVariadic(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -214,11 +214,11 @@ func TestSortingWithConditionVariadic(t *testing.T) {
 	repo.ExpectFindAll(where.Eq("available", true), sort.Asc("updated_at")).Result(books)
 	/// [sorting-with-condition-variadic]
 
-	assert.Nil(t, SortingWithConditionVariadic(ctx, repo))
+	assert.Nil(t, QuerySortingWithConditionVariadic(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestSelect(t *testing.T) {
+func TestQuerySelect(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -231,11 +231,11 @@ func TestSelect(t *testing.T) {
 	repo.ExpectFindAll(rel.Select("id", "title")).Result(books)
 	/// [select]
 
-	assert.Nil(t, Select(ctx, repo))
+	assert.Nil(t, QuerySelect(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestTable(t *testing.T) {
+func TestQueryTable(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -248,11 +248,11 @@ func TestTable(t *testing.T) {
 	repo.ExpectFindAll(rel.From("ebooks")).Result(books)
 	/// [table]
 
-	assert.Nil(t, Table(ctx, repo))
+	assert.Nil(t, QueryTable(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestTableChained(t *testing.T) {
+func TestQueryTableChained(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -265,11 +265,11 @@ func TestTableChained(t *testing.T) {
 	repo.ExpectFindAll(rel.Select("id", "title").From("ebooks")).Result(books)
 	/// [table-chained]
 
-	assert.Nil(t, TableChained(ctx, repo))
+	assert.Nil(t, QueryTableChained(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestLimitOffset(t *testing.T) {
+func TestQueryLimitOffset(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -282,11 +282,11 @@ func TestLimitOffset(t *testing.T) {
 	repo.ExpectFindAll(rel.Limit(10), rel.Offset(20)).Result(books)
 	/// [limit-offset]
 
-	assert.Nil(t, LimitOffset(ctx, repo))
+	assert.Nil(t, QueryLimitOffset(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestLimitOffsetChained(t *testing.T) {
+func TestQueryLimitOffsetChained(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -299,11 +299,11 @@ func TestLimitOffsetChained(t *testing.T) {
 	repo.ExpectFindAll(rel.Select().Limit(10).Offset(20)).Result(books)
 	/// [limit-offset-chained]
 
-	assert.Nil(t, LimitOffsetChained(ctx, repo))
+	assert.Nil(t, QueryLimitOffsetChained(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestGroup(t *testing.T) {
+func TestQueryGroup(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -319,11 +319,11 @@ func TestGroup(t *testing.T) {
 	repo.ExpectFindAll(rel.Select("category", "COUNT(id) as total").From("books").Group("category")).Result(results)
 	/// [group]
 
-	assert.Nil(t, Group(ctx, repo))
+	assert.Nil(t, QueryGroup(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestJoin(t *testing.T) {
+func TestQueryJoin(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -336,11 +336,11 @@ func TestJoin(t *testing.T) {
 	repo.ExpectFindAll(rel.Join("books").Where(where.Eq("books.name", "REL for Dummies"))).Result(transactions)
 	/// [join]
 
-	assert.Nil(t, Join(ctx, repo))
+	assert.Nil(t, QueryJoin(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestJoinOn(t *testing.T) {
+func TestQueryJoinOn(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -353,11 +353,11 @@ func TestJoinOn(t *testing.T) {
 	repo.ExpectFindAll(rel.JoinOn("books", "transactions.book_id", "books.id")).Result(transactions)
 	/// [join-on]
 
-	assert.Nil(t, JoinOn(ctx, repo))
+	assert.Nil(t, QueryJoinOn(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestJoinAlias(t *testing.T) {
+func TestQueryJoinAlias(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -370,11 +370,11 @@ func TestJoinAlias(t *testing.T) {
 	repo.ExpectFindAll(join.On("books", "transactions.book_id", "books.id")).Result(transactions)
 	/// [join-alias]
 
-	assert.Nil(t, JoinAlias(ctx, repo))
+	assert.Nil(t, QueryJoinAlias(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestJoinWith(t *testing.T) {
+func TestQueryJoinWith(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -387,11 +387,11 @@ func TestJoinWith(t *testing.T) {
 	repo.ExpectFindAll(rel.JoinWith("LEFT JOIN", "books", "transactions.book_id", "books.id")).Result(transactions)
 	/// [join-with]
 
-	assert.Nil(t, JoinWith(ctx, repo))
+	assert.Nil(t, QueryJoinWith(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestJoinFragment(t *testing.T) {
+func TestQueryJoinFragment(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -404,11 +404,11 @@ func TestJoinFragment(t *testing.T) {
 	repo.ExpectFindAll(rel.Joinf("JOIN `books` ON `transactions`.`book_id`=`books`.`id`")).Result(transactions)
 	/// [join-fragment]
 
-	assert.Nil(t, JoinFragment(ctx, repo))
+	assert.Nil(t, QueryJoinFragment(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestLock(t *testing.T) {
+func TestQueryLock(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -419,11 +419,11 @@ func TestLock(t *testing.T) {
 	repo.ExpectFind(where.Eq("id", 1), rel.Lock("FOR UPDATE")).Result(book)
 	/// [lock]
 
-	assert.Nil(t, Lock(ctx, repo))
+	assert.Nil(t, QueryLock(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestLockForUpdate(t *testing.T) {
+func TestQueryLockForUpdate(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -434,11 +434,11 @@ func TestLockForUpdate(t *testing.T) {
 	repo.ExpectFind(where.Eq("id", 1), rel.ForUpdate()).Result(book)
 	/// [lock-for-update]
 
-	assert.Nil(t, LockForUpdate(ctx, repo))
+	assert.Nil(t, QueryLockForUpdate(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestLockChained(t *testing.T) {
+func TestQueryLockChained(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -449,11 +449,11 @@ func TestLockChained(t *testing.T) {
 	repo.ExpectFind(rel.Where(where.Eq("id", 1)).Lock("FOR UPDATE")).Result(book)
 	/// [lock-chained]
 
-	assert.Nil(t, LockChained(ctx, repo))
+	assert.Nil(t, QueryLockChained(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestAggregate(t *testing.T) {
+func TestQueryAggregate(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -463,11 +463,11 @@ func TestAggregate(t *testing.T) {
 	repo.ExpectAggregate(rel.From("books").Where(where.Eq("available", true)), "count", "id").Result(5)
 	/// [aggregate]
 
-	assert.Nil(t, Aggregate(ctx, repo))
+	assert.Nil(t, QueryAggregate(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestCount(t *testing.T) {
+func TestQueryCount(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -477,11 +477,11 @@ func TestCount(t *testing.T) {
 	repo.ExpectCount("books").Result(7)
 	/// [count]
 
-	assert.Nil(t, Count(ctx, repo))
+	assert.Nil(t, QueryCount(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestCountWithCondition(t *testing.T) {
+func TestQueryCountWithCondition(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -491,11 +491,11 @@ func TestCountWithCondition(t *testing.T) {
 	repo.ExpectCount("books", where.Eq("available", true)).Result(5)
 	/// [count-with-condition]
 
-	assert.Nil(t, CountWithCondition(ctx, repo))
+	assert.Nil(t, QueryCountWithCondition(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestFindAndCountAll(t *testing.T) {
+func TestQueryFindAndCountAll(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -508,11 +508,11 @@ func TestFindAndCountAll(t *testing.T) {
 	repo.ExpectFindAndCountAll(rel.Where(where.Like("title", "%dummies%")).Limit(10).Offset(10)).Result(books, 12)
 	/// [find-and-count-all]
 
-	assert.Nil(t, FindAndCountAll(ctx, repo))
+	assert.Nil(t, QueryFindAndCountAll(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestIteration(t *testing.T) {
+func TestQueryIteration(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -523,11 +523,11 @@ func TestIteration(t *testing.T) {
 	repo.ExpectIterate(rel.From("users"), rel.BatchSize(500)).Result(users)
 	/// [batch-iteration]
 
-	assert.Nil(t, Iteration(ctx, repo))
+	assert.Nil(t, QueryIteration(ctx, repo))
 	repo.AssertExpectations(t)
 }
 
-func TestIteration_error(t *testing.T) {
+func TestQueryIteration_error(t *testing.T) {
 	var (
 		ctx  = context.TODO()
 		repo = reltest.New()
@@ -537,6 +537,22 @@ func TestIteration_error(t *testing.T) {
 	repo.ExpectIterate(rel.From("users"), rel.BatchSize(500)).ConnectionClosed()
 	/// [batch-iteration-connection-error]
 
-	assert.Equal(t, reltest.ErrConnectionClosed, Iteration(ctx, repo))
+	assert.Equal(t, reltest.ErrConnectionClosed, QueryIteration(ctx, repo))
+	repo.AssertExpectations(t)
+}
+
+func TestQuerySQL(t *testing.T) {
+	var (
+		ctx  = context.TODO()
+		repo = reltest.New()
+	)
+
+	/// [sql]
+	var book Book
+	sql := rel.SQL("SELECT id, title, price, orders = (SELECT COUNT(t.id) FROM [transactions] t WHERE t.book_id = b.id) FROM books b where b.id=?", 1)
+	repo.ExpectFind(sql).Result(book)
+	/// [sql]
+
+	assert.Nil(t, QuerySQL(ctx, repo))
 	repo.AssertExpectations(t)
 }

--- a/query.go
+++ b/query.go
@@ -36,6 +36,8 @@ func Build(table string, queriers ...Querier) Query {
 			q.Build(&query)
 		case Unscoped:
 			q.Build(&query)
+		case SQLQuery:
+			q.Build(&query)
 		}
 	}
 
@@ -59,6 +61,7 @@ type Query struct {
 	LimitQuery    Limit
 	LockQuery     Lock
 	UnscopedQuery Unscoped
+	SQLQuery      SQLQuery
 }
 
 // Build query.

--- a/query_test.go
+++ b/query_test.go
@@ -118,6 +118,17 @@ func TestQuerier(t *testing.T) {
 				LockQuery:  "FOR UPDATE",
 			},
 		},
+		{
+			name: "sql query",
+			queriers: [][]rel.Querier{
+				{
+					rel.SQL("SELECT 1"),
+				},
+			},
+			query: rel.Query{
+				SQLQuery: rel.SQL("SELECT 1"),
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/query_test.go
+++ b/query_test.go
@@ -122,11 +122,11 @@ func TestQuerier(t *testing.T) {
 			name: "sql query",
 			queriers: [][]rel.Querier{
 				{
-					rel.SQL("SELECT 1"),
+					rel.SQL("SELECT 1;"),
 				},
 			},
 			query: rel.Query{
-				SQLQuery: rel.SQL("SELECT 1"),
+				SQLQuery: rel.SQL("SELECT 1;"),
 			},
 		},
 	}

--- a/sql_query.go
+++ b/sql_query.go
@@ -1,0 +1,20 @@
+package rel
+
+// SQLQuery allows querying using native query supported by database.
+type SQLQuery struct {
+	Statement string
+	Values    []interface{}
+}
+
+// Build Raw Query.
+func (sq SQLQuery) Build(query *Query) {
+	query.SQLQuery = sq
+}
+
+// SQL Query.
+func SQL(statement string, values ...interface{}) SQLQuery {
+	return SQLQuery{
+		Statement: statement,
+		Values:    values,
+	}
+}

--- a/sql_query_test.go
+++ b/sql_query_test.go
@@ -9,11 +9,11 @@ import (
 
 func TestSQLQuery(t *testing.T) {
 	assert.Equal(t, rel.SQLQuery{
-		Statement: "SELECT 1",
-	}, rel.SQL("SELECT 1"))
+		Statement: "SELECT 1;",
+	}, rel.SQL("SELECT 1;"))
 
 	assert.Equal(t, rel.SQLQuery{
-		Statement: "SELECT * FROM `users` WHERE id=?",
+		Statement: "SELECT * FROM `users` WHERE id=?;",
 		Values:    []interface{}{1},
-	}, rel.SQL("SELECT * FROM `users` WHERE id=?", 1))
+	}, rel.SQL("SELECT * FROM `users` WHERE id=?;", 1))
 }

--- a/sql_query_test.go
+++ b/sql_query_test.go
@@ -1,0 +1,19 @@
+package rel_test
+
+import (
+	"testing"
+
+	"github.com/Fs02/rel"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSQLQuery(t *testing.T) {
+	assert.Equal(t, rel.SQLQuery{
+		Statement: "SELECT 1",
+	}, rel.SQL("SELECT 1"))
+
+	assert.Equal(t, rel.SQLQuery{
+		Statement: "SELECT * FROM `users` WHERE id=?",
+		Values:    []interface{}{1},
+	}, rel.SQL("SELECT * FROM `users` WHERE id=?", 1))
+}


### PR DESCRIPTION
Currently rel supports partial raw sql query using fragment.
With this feature, rel supports full raw sql query for complex use case.

API:
```go
err := repo.Find(&result, rel.SQL("SELECT 1+?+?", 2, 3))
```