### PR TITLE
Option to disable cascade update

### DIFF
--- a/changeset.go
+++ b/changeset.go
@@ -74,16 +74,18 @@ func (c Changeset) Apply(doc *Document, mut *Mutation) {
 		mut.Add(Set("updated_at", t))
 	}
 
-	for _, field := range doc.BelongsTo() {
-		c.applyAssoc(field, mut)
-	}
+	if mut.Cascade {
+		for _, field := range doc.BelongsTo() {
+			c.applyAssoc(field, mut)
+		}
 
-	for _, field := range doc.HasOne() {
-		c.applyAssoc(field, mut)
-	}
+		for _, field := range doc.HasOne() {
+			c.applyAssoc(field, mut)
+		}
 
-	for _, field := range doc.HasMany() {
-		c.applyAssocMany(field, mut)
+		for _, field := range doc.HasMany() {
+			c.applyAssocMany(field, mut)
+		}
 	}
 }
 

--- a/changeset_test.go
+++ b/changeset_test.go
@@ -125,7 +125,9 @@ func TestChangeset(t *testing.T) {
 	})
 
 	t.Run("apply clean", func(t *testing.T) {
-		assert.Equal(t, Mutation{}, Apply(doc, changeset))
+		assert.Equal(t, Mutation{
+			Cascade: true,
+		}, Apply(doc, changeset))
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -148,6 +150,7 @@ func TestChangeset(t *testing.T) {
 
 	t.Run("apply changeset", func(t *testing.T) {
 		assert.Equal(t, Mutation{
+			Cascade: true,
 			Mutates: map[string]Mutate{
 				"name":       Set("name", "User 2"),
 				"age":        Set("age", 21),
@@ -175,7 +178,9 @@ func TestChangeset_ptr(t *testing.T) {
 	})
 
 	t.Run("apply clean", func(t *testing.T) {
-		assert.Equal(t, Mutation{}, Apply(doc, changeset))
+		assert.Equal(t, Mutation{
+			Cascade: true,
+		}, Apply(doc, changeset))
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -190,6 +195,7 @@ func TestChangeset_ptr(t *testing.T) {
 
 	t.Run("apply changeset", func(t *testing.T) {
 		assert.Equal(t, Mutation{
+			Cascade: true,
 			Mutates: map[string]Mutate{
 				"user_id": Set("user_id", 3),
 			},
@@ -216,7 +222,9 @@ func TestChangeset_belongsTo(t *testing.T) {
 	})
 
 	t.Run("apply clean", func(t *testing.T) {
-		assert.Equal(t, Mutation{}, Apply(doc, changeset))
+		assert.Equal(t, Mutation{
+			Cascade: true,
+		}, Apply(doc, changeset))
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -232,10 +240,12 @@ func TestChangeset_belongsTo(t *testing.T) {
 
 	t.Run("apply changeset", func(t *testing.T) {
 		assert.Equal(t, Mutation{
+			Cascade: true,
 			Assoc: map[string]AssocMutation{
 				"user": AssocMutation{
 					Mutations: []Mutation{
 						{
+							Cascade: true,
 							Mutates: map[string]Mutate{
 								"name":       Set("name", "User Satu"),
 								"updated_at": Set("updated_at", now()),
@@ -263,7 +273,9 @@ func TestChangeset_belongsTo_new(t *testing.T) {
 	})
 
 	t.Run("apply clean", func(t *testing.T) {
-		assert.Equal(t, Mutation{}, Apply(doc, changeset))
+		assert.Equal(t, Mutation{
+			Cascade: true,
+		}, Apply(doc, changeset))
 	})
 
 	t.Run("create", func(t *testing.T) {
@@ -286,10 +298,12 @@ func TestChangeset_belongsTo_new(t *testing.T) {
 
 	t.Run("apply changeset", func(t *testing.T) {
 		assert.Equal(t, Mutation{
+			Cascade: true,
 			Assoc: map[string]AssocMutation{
 				"user": AssocMutation{
 					Mutations: []Mutation{
 						{
+							Cascade: true,
 							Mutates: map[string]Mutate{
 								"name":       Set("name", "User Satu"),
 								"age":        Set("age", 20),
@@ -325,7 +339,9 @@ func TestChangeset_hasOne(t *testing.T) {
 	})
 
 	t.Run("apply clean", func(t *testing.T) {
-		assert.Equal(t, Mutation{}, Apply(doc, changeset))
+		assert.Equal(t, Mutation{
+			Cascade: true,
+		}, Apply(doc, changeset))
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -345,10 +361,12 @@ func TestChangeset_hasOne(t *testing.T) {
 
 	t.Run("apply changeset", func(t *testing.T) {
 		assert.Equal(t, Mutation{
+			Cascade: true,
 			Assoc: map[string]AssocMutation{
 				"address": AssocMutation{
 					Mutations: []Mutation{
 						{
+							Cascade: true,
 							Mutates: map[string]Mutate{
 								"user_id": Set("user_id", user.ID),
 								"street":  Set("street", "Grove Street Blvd"),
@@ -377,7 +395,9 @@ func TestChangeset_hasOne_new(t *testing.T) {
 	})
 
 	t.Run("apply clean", func(t *testing.T) {
-		assert.Equal(t, Mutation{}, Apply(doc, changeset))
+		assert.Equal(t, Mutation{
+			Cascade: true,
+		}, Apply(doc, changeset))
 	})
 
 	t.Run("create", func(t *testing.T) {
@@ -400,10 +420,12 @@ func TestChangeset_hasOne_new(t *testing.T) {
 
 	t.Run("apply changeset", func(t *testing.T) {
 		assert.Equal(t, Mutation{
+			Cascade: true,
 			Assoc: map[string]AssocMutation{
 				"address": AssocMutation{
 					Mutations: []Mutation{
 						{
+							Cascade: true,
 							Mutates: map[string]Mutate{
 								"user_id":    Set("user_id", user.ID),
 								"street":     Set("street", "Grove Street Blvd"),
@@ -445,7 +467,9 @@ func TestChangeset_hasMany(t *testing.T) {
 	})
 
 	t.Run("apply clean", func(t *testing.T) {
-		assert.Equal(t, Mutation{}, Apply(doc, changeset))
+		assert.Equal(t, Mutation{
+			Cascade: true,
+		}, Apply(doc, changeset))
 	})
 
 	t.Run("update", func(t *testing.T) {
@@ -475,15 +499,18 @@ func TestChangeset_hasMany(t *testing.T) {
 
 	t.Run("apply changeset", func(t *testing.T) {
 		assert.Equal(t, Mutation{
+			Cascade: true,
 			Assoc: map[string]AssocMutation{
 				"transactions": AssocMutation{
 					Mutations: []Mutation{
 						{
+							Cascade: true,
 							Mutates: map[string]Mutate{
 								"status": Set("status", Status("paid")),
 							},
 						},
 						{
+							Cascade: true,
 							Mutates: map[string]Mutate{
 								"item":    Set("item", "Paper"),
 								"status":  Set("status", Status("pending")),

--- a/map.go
+++ b/map.go
@@ -21,6 +21,10 @@ func (m Map) Apply(doc *Document, mutation *Mutation) {
 	for field, value := range m {
 		switch v := value.(type) {
 		case Map:
+			if !mutation.Cascade {
+				continue
+			}
+
 			var (
 				assoc = doc.Association(field)
 			)
@@ -36,6 +40,9 @@ func (m Map) Apply(doc *Document, mutation *Mutation) {
 
 			mutation.SetAssoc(field, assocMutation)
 		case []Map:
+			if !mutation.Cascade {
+				continue
+			}
 			var (
 				assoc            = doc.Association(field)
 				mods, deletedIDs = applyMaps(v, assoc)

--- a/map.go
+++ b/map.go
@@ -22,32 +22,34 @@ func (m Map) Apply(doc *Document, mutation *Mutation) {
 		switch v := value.(type) {
 		case Map:
 			if !mutation.Cascade {
-
-				var (
-					assoc = doc.Association(field)
-				)
-
-				if assoc.Type() != HasOne && assoc.Type() != BelongsTo {
-					panic(fmt.Sprint("rel: cannot associate has many", v, "as", field, "into", doc.Table()))
-				}
-
-				var (
-					assocDoc, _   = assoc.Document()
-					assocMutation = Apply(assocDoc, v)
-				)
-
-				mutation.SetAssoc(field, assocMutation)
+				continue
 			}
+
+			var (
+				assoc = doc.Association(field)
+			)
+
+			if assoc.Type() != HasOne && assoc.Type() != BelongsTo {
+				panic(fmt.Sprint("rel: cannot associate has many", v, "as", field, "into", doc.Table()))
+			}
+
+			var (
+				assocDoc, _   = assoc.Document()
+				assocMutation = Apply(assocDoc, v)
+			)
+
+			mutation.SetAssoc(field, assocMutation)
 		case []Map:
-			if mutation.Cascade {
-				var (
-					assoc            = doc.Association(field)
-					mods, deletedIDs = applyMaps(v, assoc)
-				)
-
-				mutation.SetAssoc(field, mods...)
-				mutation.SetDeletedIDs(field, deletedIDs)
+			if !mutation.Cascade {
+				continue
 			}
+			var (
+				assoc            = doc.Association(field)
+				mods, deletedIDs = applyMaps(v, assoc)
+			)
+
+			mutation.SetAssoc(field, mods...)
+			mutation.SetDeletedIDs(field, deletedIDs)
 		default:
 			if field == pField {
 				if v != pValue {

--- a/map.go
+++ b/map.go
@@ -22,34 +22,32 @@ func (m Map) Apply(doc *Document, mutation *Mutation) {
 		switch v := value.(type) {
 		case Map:
 			if !mutation.Cascade {
-				continue
+
+				var (
+					assoc = doc.Association(field)
+				)
+
+				if assoc.Type() != HasOne && assoc.Type() != BelongsTo {
+					panic(fmt.Sprint("rel: cannot associate has many", v, "as", field, "into", doc.Table()))
+				}
+
+				var (
+					assocDoc, _   = assoc.Document()
+					assocMutation = Apply(assocDoc, v)
+				)
+
+				mutation.SetAssoc(field, assocMutation)
 			}
-
-			var (
-				assoc = doc.Association(field)
-			)
-
-			if assoc.Type() != HasOne && assoc.Type() != BelongsTo {
-				panic(fmt.Sprint("rel: cannot associate has many", v, "as", field, "into", doc.Table()))
-			}
-
-			var (
-				assocDoc, _   = assoc.Document()
-				assocMutation = Apply(assocDoc, v)
-			)
-
-			mutation.SetAssoc(field, assocMutation)
 		case []Map:
-			if !mutation.Cascade {
-				continue
-			}
-			var (
-				assoc            = doc.Association(field)
-				mods, deletedIDs = applyMaps(v, assoc)
-			)
+			if mutation.Cascade {
+				var (
+					assoc            = doc.Association(field)
+					mods, deletedIDs = applyMaps(v, assoc)
+				)
 
-			mutation.SetAssoc(field, mods...)
-			mutation.SetDeletedIDs(field, deletedIDs)
+				mutation.SetAssoc(field, mods...)
+				mutation.SetDeletedIDs(field, deletedIDs)
+			}
 		default:
 			if field == pField {
 				if v != pValue {

--- a/map_test.go
+++ b/map_test.go
@@ -128,7 +128,7 @@ func TestMap_hasManyUpdateDeleteInsert(t *testing.T) {
 				{"id": 3, "item": "Shield"},
 			},
 		}
-		userMutation         Mutation
+		userMutation         = Mutation{Cascade: true}
 		transaction1Mutation = Apply(NewDocument(&Transaction{}),
 			Set("item", "Sword"),
 		)

--- a/map_test.go
+++ b/map_test.go
@@ -54,6 +54,35 @@ func TestMap(t *testing.T) {
 	}, user)
 }
 
+func TestMap_CascadeDisabled(t *testing.T) {
+	var (
+		user User
+		doc  = NewDocument(&user)
+		data = Map{
+			"name": "Luffy",
+			"age":  20,
+			"transactions": []Map{
+				{"item": "Sword"},
+				{"item": "Shield"},
+			},
+			"address": Map{
+				"street": "Grove Street",
+			},
+		}
+		userMutation = Apply(NewDocument(&User{}),
+			Cascade(false),
+			Set("name", "Luffy"),
+			Set("age", 20),
+		)
+	)
+
+	assert.Equal(t, userMutation, Apply(doc, Cascade(false), data))
+	assert.Equal(t, User{
+		Name: "Luffy",
+		Age:  20,
+	}, user)
+}
+
 func TestMap_update(t *testing.T) {
 	var (
 		user = User{

--- a/mutation.go
+++ b/mutation.go
@@ -13,13 +13,17 @@ type Mutator interface {
 // Apply using given mutators.
 func Apply(doc *Document, mutators ...Mutator) Mutation {
 	var (
-		mutation     Mutation
 		optionsCount int
+		mutation     = Mutation{
+			Unscoped: false,
+			Reload:   false,
+			Cascade:  true,
+		}
 	)
 
 	for i := range mutators {
 		switch mut := mutators[i].(type) {
-		case Unscoped, Reload:
+		case Unscoped, Reload, Cascade:
 			optionsCount++
 			mut.Apply(doc, &mutation)
 		default:
@@ -48,6 +52,7 @@ type Mutation struct {
 	Assoc    map[string]AssocMutation
 	Unscoped Unscoped
 	Reload   Reload
+	Cascade  Cascade
 }
 
 func (m *Mutation) initMutates() {
@@ -204,9 +209,19 @@ func SetFragment(raw string, args ...interface{}) Mutate {
 var Setf = SetFragment
 
 // Reload force reload after insert/update.
+// Default to false.
 type Reload bool
 
 // Apply mutation.
 func (r Reload) Apply(doc *Document, mutation *Mutation) {
 	mutation.Reload = r
+}
+
+// Cascade enable or disable updating associations.
+// Default to true.
+type Cascade bool
+
+// Apply mutation.
+func (c Cascade) Apply(doc *Document, mutation *Mutation) {
+	mutation.Cascade = c
 }

--- a/mutation_test.go
+++ b/mutation_test.go
@@ -27,6 +27,7 @@ func TestApplyMutation(t *testing.T) {
 			SetFragment("field6=?", true),
 		}
 		mutation = Mutation{
+			Cascade: true,
 			Mutates: map[string]Mutate{
 				"field1":   Set("field1", "string"),
 				"field2":   Set("field2", true),
@@ -47,26 +48,6 @@ func TestApplyMutation(t *testing.T) {
 	// non set op won't update the struct
 	assert.Equal(t, 0, record.Field4)
 	assert.Equal(t, 0, record.Field5)
-}
-
-func TestApplyMutation_Reload(t *testing.T) {
-	var (
-		record   = TestRecord{}
-		doc      = NewDocument(&record)
-		mutators = []Mutator{
-			Set("field1", "string"),
-			Reload(true),
-		}
-		mutation = Mutation{
-			Mutates: map[string]Mutate{
-				"field1": Set("field1", "string"),
-			},
-			Reload: true,
-		}
-	)
-
-	assert.Equal(t, mutation, Apply(doc, mutators...))
-	assert.Equal(t, "string", record.Field1)
 }
 
 func TestApplyMutation_setValueError(t *testing.T) {
@@ -103,4 +84,45 @@ func TestApplyMutation_unknownFieldValueError(t *testing.T) {
 		Apply(doc, Dec("field0"))
 	})
 	assert.Equal(t, "", record.Field1)
+}
+
+func TestApplyMutation_Reload(t *testing.T) {
+	var (
+		record   = TestRecord{}
+		doc      = NewDocument(&record)
+		mutators = []Mutator{
+			Set("field1", "string"),
+			Reload(true),
+		}
+		mutation = Mutation{
+			Mutates: map[string]Mutate{
+				"field1": Set("field1", "string"),
+			},
+			Reload:  true,
+			Cascade: true,
+		}
+	)
+
+	assert.Equal(t, mutation, Apply(doc, mutators...))
+	assert.Equal(t, "string", record.Field1)
+}
+
+func TestApplyMutation_Cascade(t *testing.T) {
+	var (
+		record   = TestRecord{}
+		doc      = NewDocument(&record)
+		mutators = []Mutator{
+			Set("field1", "string"),
+			Cascade(false),
+		}
+		mutation = Mutation{
+			Mutates: map[string]Mutate{
+				"field1": Set("field1", "string"),
+			},
+			Cascade: false,
+		}
+	)
+
+	assert.Equal(t, mutation, Apply(doc, mutators...))
+	assert.Equal(t, "string", record.Field1)
 }

--- a/structset.go
+++ b/structset.go
@@ -45,7 +45,9 @@ func (s Structset) Apply(doc *Document, mut *Mutation) {
 		s.applyValue(doc, mut, field)
 	}
 
-	s.applyAssoc(mut)
+	if mut.Cascade {
+		s.applyAssoc(mut)
+	}
 }
 
 func (s Structset) set(doc *Document, mut *Mutation, field string, value interface{}, force bool) {

--- a/structset_test.go
+++ b/structset_test.go
@@ -39,6 +39,7 @@ func TestStructset(t *testing.T) {
 		}
 		doc      = NewDocument(&user)
 		mutation = Mutation{
+			Cascade: true,
 			Mutates: map[string]Mutate{
 				"name":       Set("name", "Luffy"),
 				"age":        Set("age", 0),
@@ -59,6 +60,7 @@ func TestStructset_skipZero(t *testing.T) {
 		}
 		doc      = NewDocument(&user)
 		mutation = Mutation{
+			Cascade: true,
 			Mutates: map[string]Mutate{
 				"name":       Set("name", "Luffy"),
 				"created_at": Set("created_at", now()),


### PR DESCRIPTION
when disabled, association won't be inserted/updated:

```go
repo.Insert(&user, Cascade(false))
repo.Update(&user, Cascade(false))
```

If cascade is used alongside custom mutators, it's recommended to specify cascade first before other mutator to prevent other mutator applying mutation to the struct:

```go
repo.Insert(&user, Cascade(false), rel.Map{})
repo.Update(&user, Cascade(false), rel.Map{})
```