### PR TITLE
Allow explicitly set value for primary key when inserting records

### DIFF
--- a/structset.go
+++ b/structset.go
@@ -27,7 +27,9 @@ func (s Structset) Apply(doc *Document, mut *Mutation) {
 	for _, field := range s.doc.Fields() {
 		switch field {
 		case pField:
-			continue
+			if v, ok := doc.Value(field); ok && isZero(v) {
+				continue // skip zero primary key value so it can be populated by database
+			}
 		case "created_at", "inserted_at":
 			if doc.Flag(HasCreatedAt) {
 				if value, ok := doc.Value(field); ok && value.(time.Time).IsZero() {

--- a/structset_test.go
+++ b/structset_test.go
@@ -53,7 +53,7 @@ func TestStructset(t *testing.T) {
 	assert.Equal(t, mutation, Apply(doc, NewStructset(&user, false)))
 }
 
-func TestStructsetSkipZeroPrimaryKey(t *testing.T) {
+func TestStructset_skipZeroPrimaryKey(t *testing.T) {
 	var (
 		user = User{
 			Name: "Luffy",

--- a/structset_test.go
+++ b/structset_test.go
@@ -41,6 +41,27 @@ func TestStructset(t *testing.T) {
 		mutation = Mutation{
 			Cascade: true,
 			Mutates: map[string]Mutate{
+				"id":         Set("id", 1),
+				"name":       Set("name", "Luffy"),
+				"age":        Set("age", 0),
+				"created_at": Set("created_at", now()),
+				"updated_at": Set("updated_at", now()),
+			},
+		}
+	)
+
+	assert.Equal(t, mutation, Apply(doc, NewStructset(&user, false)))
+}
+
+func TestStructsetSkipZeroPrimaryKey(t *testing.T) {
+	var (
+		user = User{
+			Name: "Luffy",
+		}
+		doc      = NewDocument(&user)
+		mutation = Mutation{
+			Cascade: true,
+			Mutates: map[string]Mutate{
 				"name":       Set("name", "Luffy"),
 				"age":        Set("age", 0),
 				"created_at": Set("created_at", now()),
@@ -62,6 +83,7 @@ func TestStructset_skipZero(t *testing.T) {
 		mutation = Mutation{
 			Cascade: true,
 			Mutates: map[string]Mutate{
+				"id":         Set("id", 1),
 				"name":       Set("name", "Luffy"),
 				"created_at": Set("created_at", now()),
 				"updated_at": Set("updated_at", now()),
@@ -91,24 +113,28 @@ func TestStructset_withAssoc(t *testing.T) {
 		}
 		doc     = NewDocument(&user)
 		userMod = Apply(NewDocument(&User{}),
+			Set("id", 1),
 			Set("name", "Luffy"),
 			Set("age", 20),
 			Set("created_at", createdAt),
 			Set("updated_at", now()),
 		)
 		trx1Mod = Apply(NewDocument(&Transaction{}),
+			Set("id", 1),
 			Set("item", "Sword"),
 			Set("status", Status("")),
 			Set("user_id", 0),
 			Set("address_id", 0),
 		)
 		trx2Mod = Apply(NewDocument(&Transaction{}),
+			Set("id", 2),
 			Set("item", "Shield"),
 			Set("status", Status("")),
 			Set("user_id", 0),
 			Set("address_id", 0),
 		)
 		addrMod = Apply(NewDocument(&Address{}),
+			Set("id", 1),
 			Set("street", "Grove Street"),
 			Set("notes", Notes("")),
 			Set("user_id", nil),


### PR DESCRIPTION
This change allows to pre-populate primary key value when using `repo.Insert`. In case value is not set rel will fallback to existing behaviour of skipping primary key in INSERT query and letting database to generate primary key.

This pull request implements solution discussed in #81.

**This change might be potentially backwards incompatible.**