### PR TITLE
Skip preload if its already loaded

### DIFF
--- a/changeset_test.go
+++ b/changeset_test.go
@@ -242,7 +242,7 @@ func TestChangeset_belongsTo(t *testing.T) {
 		assert.Equal(t, Mutation{
 			Cascade: true,
 			Assoc: map[string]AssocMutation{
-				"user": AssocMutation{
+				"user": {
 					Mutations: []Mutation{
 						{
 							Cascade: true,
@@ -300,7 +300,7 @@ func TestChangeset_belongsTo_new(t *testing.T) {
 		assert.Equal(t, Mutation{
 			Cascade: true,
 			Assoc: map[string]AssocMutation{
-				"user": AssocMutation{
+				"user": {
 					Mutations: []Mutation{
 						{
 							Cascade: true,
@@ -363,7 +363,7 @@ func TestChangeset_hasOne(t *testing.T) {
 		assert.Equal(t, Mutation{
 			Cascade: true,
 			Assoc: map[string]AssocMutation{
-				"address": AssocMutation{
+				"address": {
 					Mutations: []Mutation{
 						{
 							Cascade: true,
@@ -422,7 +422,7 @@ func TestChangeset_hasOne_new(t *testing.T) {
 		assert.Equal(t, Mutation{
 			Cascade: true,
 			Assoc: map[string]AssocMutation{
-				"address": AssocMutation{
+				"address": {
 					Mutations: []Mutation{
 						{
 							Cascade: true,
@@ -503,7 +503,7 @@ func TestChangeset_hasMany(t *testing.T) {
 		assert.Equal(t, Mutation{
 			Cascade: true,
 			Assoc: map[string]AssocMutation{
-				"transactions": AssocMutation{
+				"transactions": {
 					Mutations: []Mutation{
 						{
 							Cascade: true,

--- a/mutation.go
+++ b/mutation.go
@@ -218,6 +218,11 @@ func (r Reload) Apply(doc *Document, mutation *Mutation) {
 	mutation.Reload = r
 }
 
+// Build query.
+func (r Reload) Build(query *Query) {
+	query.ReloadQuery = r
+}
+
 // Cascade enable or disable updating associations.
 // Default to true.
 type Cascade bool

--- a/query.go
+++ b/query.go
@@ -36,6 +36,8 @@ func Build(table string, queriers ...Querier) Query {
 			q.Build(&query)
 		case Unscoped:
 			q.Build(&query)
+		case Reload:
+			q.Build(&query)
 		case SQLQuery:
 			q.Build(&query)
 		}
@@ -61,6 +63,7 @@ type Query struct {
 	LimitQuery    Limit
 	LockQuery     Lock
 	UnscopedQuery Unscoped
+	ReloadQuery   Reload
 	SQLQuery      SQLQuery
 }
 
@@ -101,6 +104,8 @@ func (q Query) Build(query *Query) {
 		if q.LockQuery != "" {
 			query.LockQuery = q.LockQuery
 		}
+
+		query.ReloadQuery = q.ReloadQuery
 	}
 }
 
@@ -254,6 +259,12 @@ func (q Query) Lock(lock string) Query {
 // Unscoped allows soft-delete to be ignored.
 func (q Query) Unscoped() Query {
 	q.UnscopedQuery = true
+	return q
+}
+
+// Reload force reloading association on preload.
+func (q Query) Reload() Query {
+	q.ReloadQuery = true
 	return q
 }
 

--- a/repository.go
+++ b/repository.go
@@ -844,6 +844,8 @@ func (r repository) deleteAll(cw contextWrapper, flag DocumentFlag, query Query)
 }
 
 // Preload loads association with given query.
+// If association is already loaded, this will do nothing.
+// To force preloading even though association is already loaeded, add `Reload(true)` as query.
 func (r repository) Preload(ctx context.Context, records interface{}, field string, queriers ...Querier) error {
 	finish := r.instrument(ctx, "rel-preload", "preloading associations")
 	defer finish(nil)

--- a/repository.go
+++ b/repository.go
@@ -867,25 +867,16 @@ func (r repository) Preload(ctx context.Context, records interface{}, field stri
 	}
 
 	var (
-		targets, table, keyField, keyType, ddata = r.mapPreloadTargets(sl, path)
+		targets, table, keyField, keyType, ddata, loaded = r.mapPreloadTargets(sl, path)
+		ids                                              = r.targetIDs(targets)
+		query                                            = Build(table, append(queriers, In(keyField, ids...))...)
 	)
 
-	if len(targets) == 0 {
+	if len(targets) == 0 || loaded && !bool(query.ReloadQuery) {
 		return nil
 	}
 
 	var (
-		ids = make([]interface{}, len(targets))
-		i   = 0
-	)
-
-	for key := range targets {
-		ids[i] = key
-		i++
-	}
-
-	var (
-		query    = Build(table, append(queriers, In(keyField, ids...))...)
 		cur, err = cw.adapter.Query(cw.ctx, r.withDefaultScope(ddata, query))
 	)
 
@@ -905,7 +896,7 @@ func (r repository) MustPreload(ctx context.Context, records interface{}, field 
 	must(r.Preload(ctx, records, field, queriers...))
 }
 
-func (r repository) mapPreloadTargets(sl slice, path []string) (map[interface{}][]slice, string, string, reflect.Type, documentData) {
+func (r repository) mapPreloadTargets(sl slice, path []string) (map[interface{}][]slice, string, string, reflect.Type, documentData, bool) {
 	type frame struct {
 		index int
 		doc   *Document
@@ -916,6 +907,7 @@ func (r repository) mapPreloadTargets(sl slice, path []string) (map[interface{}]
 		keyField  string
 		keyType   reflect.Type
 		ddata     documentData
+		loaded    = true
 		mapTarget = make(map[interface{}][]slice)
 		stack     = make([]frame, sl.Len())
 	)
@@ -936,8 +928,9 @@ func (r repository) mapPreloadTargets(sl slice, path []string) (map[interface{}]
 
 		if top.index == len(path)-1 {
 			var (
-				target slice
-				ref    = assocs.ReferenceValue()
+				target       slice
+				targetLoaded bool
+				ref          = assocs.ReferenceValue()
 			)
 
 			if ref == nil {
@@ -945,13 +938,14 @@ func (r repository) mapPreloadTargets(sl slice, path []string) (map[interface{}]
 			}
 
 			if assocs.Type() == HasMany {
-				target, _ = assocs.Collection()
+				target, targetLoaded = assocs.Collection()
 			} else {
-				target, _ = assocs.Document()
+				target, targetLoaded = assocs.Document()
 			}
 
 			target.Reset()
 			mapTarget[ref] = append(mapTarget[ref], target)
+			loaded = loaded && targetLoaded
 
 			if table == "" {
 				table = target.Table()
@@ -995,7 +989,21 @@ func (r repository) mapPreloadTargets(sl slice, path []string) (map[interface{}]
 
 	}
 
-	return mapTarget, table, keyField, keyType, ddata
+	return mapTarget, table, keyField, keyType, ddata, loaded
+}
+
+func (r repository) targetIDs(targets map[interface{}][]slice) []interface{} {
+	var (
+		ids = make([]interface{}, len(targets))
+		i   = 0
+	)
+
+	for key := range targets {
+		ids[i] = key
+		i++
+	}
+
+	return ids
 }
 
 func (r repository) withDefaultScope(ddata documentData, query Query) Query {


### PR DESCRIPTION
> Possible breaking changes

Every preload will check and only performs preload if the association is not yet loaded.
to force association to be reloaded, you can use Reload(true).