### PR TITLE
Composite primary key

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ REL is golang orm-ish database layer for layered architecture. It's testable and
 - Elegant, yet extendable query builder with mix of syntactic sugar.
 - Supports Eager loading.
 - Supports nested transactions.
+- Composite Primary Key.
 - Multi adapter.
 - Soft Deletion.
 - Pagination.

--- a/association.go
+++ b/association.go
@@ -62,17 +62,15 @@ func (a Association) Document() (*Document, bool) {
 
 		var (
 			doc = NewDocument(rv)
-			id  = doc.PrimaryValue()
 		)
 
-		return doc, !isZero(id)
+		return doc, doc.Persisted()
 	default:
 		var (
 			doc = NewDocument(rv.Addr())
-			id  = doc.PrimaryValue()
 		)
 
-		return doc, !isZero(id)
+		return doc, doc.Persisted()
 	}
 }
 

--- a/collection.go
+++ b/collection.go
@@ -59,12 +59,12 @@ func (c Collection) tableName() string {
 }
 
 // PrimaryField column name of this collection.
-func (c Collection) PrimaryField() string {
+func (c Collection) PrimaryField() []string {
 	if p, ok := c.v.(primary); ok {
 		return p.PrimaryField()
 	}
 
-	if c.data.primaryField == "" {
+	if len(c.data.primaryField) == 0 {
 		panic("rel: failed to infer primary key for type " + c.rt.String())
 	}
 
@@ -73,30 +73,29 @@ func (c Collection) PrimaryField() string {
 
 // PrimaryValue of collection.
 // Returned value will be interface of slice interface.
-func (c Collection) PrimaryValue() interface{} {
+func (c Collection) PrimaryValue() []interface{} {
 	if p, ok := c.v.(primary); ok {
 		return p.PrimaryValue()
 	}
 
 	var (
-		index = c.data.primaryIndex
-		ids   = make([]interface{}, c.rv.Len())
+		index   = c.data.primaryIndex
+		pValues = make([]interface{}, len(index))
 	)
 
-	for i := 0; i < len(ids); i++ {
+	for i := range index {
 		var (
-			fv = c.rv.Index(i)
+			values = make([]interface{}, c.rv.Len())
 		)
 
-		if index == -2 {
-			// using interface
-			ids[i] = fv.Interface().(primary).PrimaryValue()
-		} else {
-			ids[i] = fv.Field(index).Interface()
+		for j := range values {
+			values[j] = c.rv.Index(j).Field(index[i]).Interface()
 		}
+
+		pValues[i] = values
 	}
 
-	return ids
+	return pValues
 }
 
 // Get an element from the underlying slice as a document.

--- a/collection.go
+++ b/collection.go
@@ -58,10 +58,10 @@ func (c Collection) tableName() string {
 	return tableName(rt)
 }
 
-// PrimaryField column name of this collection.
-func (c Collection) PrimaryField() []string {
+// PrimaryFields column name of this collection.
+func (c Collection) PrimaryFields() []string {
 	if p, ok := c.v.(primary); ok {
-		return p.PrimaryField()
+		return p.PrimaryFields()
 	}
 
 	if len(c.data.primaryField) == 0 {
@@ -71,31 +71,68 @@ func (c Collection) PrimaryField() []string {
 	return c.data.primaryField
 }
 
-// PrimaryValue of collection.
+// PrimaryField column name of this document.
+// panic if document uses composite key.
+func (c Collection) PrimaryField() string {
+	if fields := c.PrimaryFields(); len(fields) == 1 {
+		return fields[0]
+	}
+
+	panic("rel: composite primary key is not supported")
+}
+
+// PrimaryValues of collection.
 // Returned value will be interface of slice interface.
-func (c Collection) PrimaryValue() []interface{} {
+func (c Collection) PrimaryValues() []interface{} {
 	if p, ok := c.v.(primary); ok {
-		return p.PrimaryValue()
+		return p.PrimaryValues()
 	}
 
 	var (
 		index   = c.data.primaryIndex
-		pValues = make([]interface{}, len(index))
+		pValues = make([]interface{}, len(c.PrimaryFields()))
 	)
 
-	for i := range index {
+	if index != nil {
+		for i := range index {
+			var (
+				values = make([]interface{}, c.rv.Len())
+			)
+
+			for j := range values {
+				values[j] = c.rv.Index(j).Field(index[i]).Interface()
+			}
+
+			pValues[i] = values
+		}
+	} else {
+		// using interface.
 		var (
-			values = make([]interface{}, c.rv.Len())
+			tmp = make([][]interface{}, len(pValues))
 		)
 
-		for j := range values {
-			values[j] = c.rv.Index(j).Field(index[i]).Interface()
+		for i := 0; i < c.rv.Len(); i++ {
+			for j, id := range c.rv.Index(i).Interface().(primary).PrimaryValues() {
+				tmp[j] = append(tmp[j], id)
+			}
 		}
 
-		pValues[i] = values
+		for i := range tmp {
+			pValues[i] = tmp[i]
+		}
 	}
 
 	return pValues
+}
+
+// PrimaryValue of this document.
+// panic if document uses composite key.
+func (c Collection) PrimaryValue() interface{} {
+	if values := c.PrimaryValues(); len(values) == 1 {
+		return values[0]
+	}
+
+	panic("rel: composite primary key is not supported")
 }
 
 // Get an element from the underlying slice as a document.

--- a/collection_test.go
+++ b/collection_test.go
@@ -14,11 +14,11 @@ func (it *Items) Table() string {
 	return "_items"
 }
 
-func (it *Items) PrimaryField() string {
-	return "_uuid"
+func (it *Items) PrimaryFields() []string {
+	return []string{"_uuid"}
 }
 
-func (it *Items) PrimaryValue() interface{} {
+func (it *Items) PrimaryValue() []interface{} {
 	var (
 		ids = make([]interface{}, len(*it))
 	)
@@ -27,7 +27,7 @@ func (it *Items) PrimaryValue() interface{} {
 		ids[i] = (*it)[i].UUID
 	}
 
-	return ids
+	return []interface{}{ids}
 }
 
 func TestCollection_ReflectValue(t *testing.T) {

--- a/collection_test.go
+++ b/collection_test.go
@@ -18,7 +18,7 @@ func (it *Items) PrimaryFields() []string {
 	return []string{"_uuid"}
 }
 
-func (it *Items) PrimaryValue() []interface{} {
+func (it *Items) PrimaryValues() []interface{} {
 	var (
 		ids = make([]interface{}, len(*it))
 	)
@@ -156,12 +156,37 @@ func TestCollection_Primary_usingTag(t *testing.T) {
 			{ExternalID: 1},
 			{ExternalID: 2},
 		}
-		doc = NewCollection(&records)
+		col = NewCollection(&records)
 	)
 
 	// infer primary key
-	assert.Equal(t, "external_id", doc.PrimaryField())
-	assert.Equal(t, []interface{}{1, 2}, doc.PrimaryValue())
+	assert.Equal(t, "external_id", col.PrimaryField())
+	assert.Equal(t, []interface{}{1, 2}, col.PrimaryValue())
+}
+
+func TestCollection_Primary_composite(t *testing.T) {
+	var (
+		userRole = []UserRole{
+			{UserID: 1, RoleID: 2},
+			{UserID: 3, RoleID: 4},
+			{UserID: 5, RoleID: 6},
+		}
+		col = NewCollection(&userRole)
+	)
+
+	assert.Panics(t, func() {
+		col.PrimaryField()
+	})
+
+	assert.Panics(t, func() {
+		col.PrimaryValue()
+	})
+
+	assert.Equal(t, []string{"user_id", "role_id"}, col.PrimaryFields())
+	assert.Equal(t, []interface{}{
+		[]interface{}{1, 3, 5},
+		[]interface{}{2, 4, 6},
+	}, col.PrimaryValues())
 }
 
 func TestCollection_Primary_notFound(t *testing.T) {
@@ -170,11 +195,11 @@ func TestCollection_Primary_notFound(t *testing.T) {
 			ExternalID int
 			Name       string
 		}{}
-		doc = NewCollection(&records)
+		col = NewCollection(&records)
 	)
 
 	assert.Panics(t, func() {
-		doc.PrimaryField()
+		col.PrimaryField()
 	})
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ REL is golang orm-ish database layer for layered architecture. It's testable and
 - Elegant, yet extendable query builder with mix of syntactic sugar.
 - Supports Eager loading.
 - Supports nested transactions.
+- Composite Primary Key.
 - Multi adapter.
 - Soft Deletion.
 - Pagination.

--- a/docs/basics.md
+++ b/docs/basics.md
@@ -66,7 +66,7 @@ type Book struct {
 
 ### Primary Key
 
-REL requires every struct to have at least `primary` key. by default field named `id` will be used as primary key. to use other field as primary key. you may define it as `primary` using `db` tag.
+REL requires every struct to have at least `primary` key. by default field named `id` will be used as primary key. To use other field as primary key, you may define it as `primary` using `db` tag. Defining multiple field as primary will forms composite primary key.
 
 
 ```go

--- a/document.go
+++ b/document.go
@@ -46,8 +46,8 @@ type table interface {
 }
 
 type primary interface {
-	PrimaryField() []string
-	PrimaryValue() []interface{}
+	PrimaryFields() []string
+	PrimaryValues() []interface{}
 }
 
 type primaryData struct {
@@ -89,10 +89,10 @@ func (d Document) Table() string {
 	return tableName(d.rt)
 }
 
-// PrimaryField column name of this document.
-func (d Document) PrimaryField() []string {
+// PrimaryFields column name of this document.
+func (d Document) PrimaryFields() []string {
 	if p, ok := d.v.(primary); ok {
-		return p.PrimaryField()
+		return p.PrimaryFields()
 	}
 
 	if len(d.data.primaryField) == 0 {
@@ -102,10 +102,20 @@ func (d Document) PrimaryField() []string {
 	return d.data.primaryField
 }
 
-// PrimaryValue of this document.
-func (d Document) PrimaryValue() []interface{} {
+// PrimaryField column name of this document.
+// panic if document uses composite key.
+func (d Document) PrimaryField() string {
+	if fields := d.PrimaryFields(); len(fields) == 1 {
+		return fields[0]
+	}
+
+	panic("rel: composite primary key is not supported")
+}
+
+// PrimaryValues of this document.
+func (d Document) PrimaryValues() []interface{} {
 	if p, ok := d.v.(primary); ok {
-		return p.PrimaryValue()
+		return p.PrimaryValues()
 	}
 
 	if len(d.data.primaryIndex) == 0 {
@@ -123,14 +133,24 @@ func (d Document) PrimaryValue() []interface{} {
 	return pValues
 }
 
+// PrimaryValue of this document.
+// panic if document uses composite key.
+func (d Document) PrimaryValue() interface{} {
+	if values := d.PrimaryValues(); len(values) == 1 {
+		return values[0]
+	}
+
+	panic("rel: composite primary key is not supported")
+}
+
 // Persisted returns true if document primary key is not zero.
 func (d Document) Persisted() bool {
 	var (
-		pValue = d.PrimaryValue()
+		pValues = d.PrimaryValues()
 	)
 
-	for i := range pValue {
-		if !isZero(pValue[i]) {
+	for i := range pValues {
+		if !isZero(pValues[i]) {
 			return true
 		}
 	}
@@ -493,7 +513,7 @@ func searchPrimary(rt reflect.Type) ([]string, []int) {
 			v = reflect.Zero(rt).Interface().(primary)
 		)
 
-		field = v.PrimaryField()
+		field = v.PrimaryFields()
 		// index = -2 // special index to mark interface usage
 	} else {
 		for i := 0; i < rt.NumField(); i++ {

--- a/document.go
+++ b/document.go
@@ -514,7 +514,7 @@ func searchPrimary(rt reflect.Type) ([]string, []int) {
 		)
 
 		field = v.PrimaryFields()
-		// index = -2 // special index to mark interface usage
+		// index kept nil to mark interface usage
 	} else {
 		for i := 0; i < rt.NumField(); i++ {
 			sf := rt.Field(i)

--- a/document_test.go
+++ b/document_test.go
@@ -19,12 +19,12 @@ func (i Item) Table() string {
 	return "_items"
 }
 
-func (i Item) PrimaryField() string {
-	return "_uuid"
+func (i Item) PrimaryFields() []string {
+	return []string{"_uuid"}
 }
 
-func (i Item) PrimaryValue() interface{} {
-	return i.UUID
+func (i Item) PrimaryValues() []interface{} {
+	return []interface{}{i.UUID}
 }
 
 func TestDocument_ReflectValue(t *testing.T) {

--- a/document_test.go
+++ b/document_test.go
@@ -148,6 +148,24 @@ func TestDocument_Primary_notFound(t *testing.T) {
 	})
 }
 
+func TestDocument_Primary_composite(t *testing.T) {
+	var (
+		userRole = UserRole{UserID: 1, RoleID: 2}
+		doc      = NewDocument(&userRole)
+	)
+
+	assert.Panics(t, func() {
+		doc.PrimaryField()
+	})
+
+	assert.Panics(t, func() {
+		doc.PrimaryValue()
+	})
+
+	assert.Equal(t, []string{"user_id", "role_id"}, doc.PrimaryFields())
+	assert.Equal(t, []interface{}{1, 2}, doc.PrimaryValues())
+}
+
 func TestDocument_Fields(t *testing.T) {
 	var (
 		record = struct {
@@ -377,13 +395,13 @@ func TestDocument_Association(t *testing.T) {
 			name:    "User",
 			record:  &User{},
 			hasOne:  []string{"address"},
-			hasMany: []string{"transactions"},
+			hasMany: []string{"transactions", "user_roles"},
 		},
 		{
 			name:    "User Cached",
 			record:  &User{},
 			hasOne:  []string{"address"},
-			hasMany: []string{"transactions"},
+			hasMany: []string{"transactions", "user_roles"},
 		},
 		{
 			name:      "Transaction",

--- a/filter_query.go
+++ b/filter_query.go
@@ -1,6 +1,8 @@
 package rel
 
-import "errors"
+import (
+	"errors"
+)
 
 // FilterOp defines enumeration of all supported filter types.
 type FilterOp int

--- a/filter_query.go
+++ b/filter_query.go
@@ -1,5 +1,7 @@
 package rel
 
+import "errors"
+
 // FilterOp defines enumeration of all supported filter types.
 type FilterOp int
 
@@ -495,4 +497,101 @@ func FilterFragment(expr string, values ...interface{}) FilterQuery {
 		Field: expr,
 		Value: values,
 	}
+}
+
+func filterDocument(doc *Document) FilterQuery {
+	var (
+		pFields = doc.PrimaryFields()
+		pValues = doc.PrimaryValues()
+	)
+
+	return filterDocumentPrimary(pFields, pValues, FilterEqOp)
+}
+
+func filterDocumentPrimary(pFields []string, pValues []interface{}, op FilterOp) FilterQuery {
+	var filter FilterQuery
+
+	for i := range pFields {
+		filter = filter.And(FilterQuery{
+			Type:  op,
+			Field: pFields[i],
+			Value: pValues[i],
+		})
+	}
+
+	return filter
+
+}
+
+func filterCollection(col *Collection) FilterQuery {
+	var (
+		pFields = col.PrimaryFields()
+		pValues = col.PrimaryValues()
+		length  = col.Len()
+	)
+
+	return filterCollectionPrimary(pFields, pValues, length)
+}
+
+func filterCollectionPrimary(pFields []string, pValues []interface{}, length int) FilterQuery {
+	var filter FilterQuery
+
+	if len(pFields) == 1 {
+		filter = In(pFields[0], pValues[0].([]interface{})...)
+	} else {
+		var (
+			andFilters = make([]FilterQuery, length)
+		)
+
+		for i := range pValues {
+			var (
+				values = pValues[i].([]interface{})
+			)
+
+			for j := range values {
+				andFilters[j] = andFilters[j].AndEq(pFields[i], values[j])
+			}
+		}
+
+		filter = Or(andFilters...)
+	}
+
+	return filter
+}
+
+func filterBelongsTo(assoc Association) (FilterQuery, error) {
+	var (
+		rValue = assoc.ReferenceValue()
+		fValue = assoc.ForeignValue()
+		filter = Eq(assoc.ForeignField(), fValue)
+	)
+
+	if rValue != fValue {
+		return filter, ConstraintError{
+			Key:  assoc.ReferenceField(),
+			Type: ForeignKeyConstraint,
+			Err:  errors.New("rel: inconsistent belongs to ref and fk"),
+		}
+	}
+
+	return filter, nil
+}
+
+func filterHasOne(assoc Association, asssocDoc *Document) (FilterQuery, error) {
+	var (
+		fField = assoc.ForeignField()
+		fValue = assoc.ForeignValue()
+		rValue = assoc.ReferenceValue()
+		filter = filterDocument(asssocDoc).AndEq(fField, rValue)
+	)
+
+	if rValue != fValue {
+		return filter, ConstraintError{
+			Key:  fField,
+			Type: ForeignKeyConstraint,
+			Err:  errors.New("rel: inconsistent has one ref and fk"),
+		}
+	}
+
+	return filter, nil
 }

--- a/filter_query_test.go
+++ b/filter_query_test.go
@@ -1,153 +1,152 @@
-package rel_test
+package rel
 
 import (
 	"testing"
 
-	"github.com/Fs02/rel"
 	"github.com/stretchr/testify/assert"
 )
 
-var result rel.Query
+var result Query
 
 func BenchmarkFilterQuery_chain1(b *testing.B) {
-	var query rel.Query
+	var query Query
 	for n := 0; n < b.N; n++ {
-		query = rel.Build("test", rel.Eq("id", 1))
+		query = Build("test", Eq("id", 1))
 	}
 	result = query
 }
 
 func BenchmarkFilterQuery_chain2(b *testing.B) {
-	var query rel.Query
+	var query Query
 	for n := 0; n < b.N; n++ {
-		query = rel.Build("test", rel.Eq("id", 1).AndNe("name", "foo"))
+		query = Build("test", Eq("id", 1).AndNe("name", "foo"))
 	}
 	result = query
 }
 
 func BenchmarkFilterQuery_chain3(b *testing.B) {
-	var query rel.Query
+	var query Query
 	for n := 0; n < b.N; n++ {
-		query = rel.Build("test", rel.Eq("id", 1).AndNe("name", "foo").AndGt("score", 80))
+		query = Build("test", Eq("id", 1).AndNe("name", "foo").AndGt("score", 80))
 	}
 	result = query
 }
 
 func BenchmarkFilterQuery_chain4(b *testing.B) {
-	var query rel.Query
+	var query Query
 	for n := 0; n < b.N; n++ {
-		query = rel.Build("test", rel.Eq("id", 1).AndNe("name", "foo").AndGt("score", 80).AndLt("avg", 10))
+		query = Build("test", Eq("id", 1).AndNe("name", "foo").AndGt("score", 80).AndLt("avg", 10))
 	}
 	result = query
 }
 
 func BenchmarkFilterQuery_slice1(b *testing.B) {
-	var query rel.Query
+	var query Query
 	for n := 0; n < b.N; n++ {
-		query = rel.Build("test", rel.And(rel.Eq("id", 1)))
+		query = Build("test", And(Eq("id", 1)))
 	}
 	result = query
 }
 
 func BenchmarkFilterQuery_slice2(b *testing.B) {
-	var query rel.Query
+	var query Query
 	for n := 0; n < b.N; n++ {
-		query = rel.Build("test", rel.And(rel.Eq("id", 1), rel.Ne("name", "foo")))
+		query = Build("test", And(Eq("id", 1), Ne("name", "foo")))
 	}
 	result = query
 }
 
 func BenchmarkFilterQuery_slice3(b *testing.B) {
-	var query rel.Query
+	var query Query
 	for n := 0; n < b.N; n++ {
-		query = rel.Build("test", rel.And(rel.Eq("id", 1), rel.Ne("name", "foo"), rel.Gt("score", 80)))
+		query = Build("test", And(Eq("id", 1), Ne("name", "foo"), Gt("score", 80)))
 	}
 	result = query
 }
 
 func BenchmarkFilterQuery_slice4(b *testing.B) {
-	var query rel.Query
+	var query Query
 	for n := 0; n < b.N; n++ {
-		query = rel.Build("test", rel.And(rel.Eq("id", 1), rel.Ne("name", "foo"), rel.Gt("score", 80), rel.Lt("avg", 10)))
+		query = Build("test", And(Eq("id", 1), Ne("name", "foo"), Gt("score", 80), Lt("avg", 10)))
 	}
 	result = query
 }
 
-var filter1 = rel.Eq("id", 1)
-var filter2 = rel.Ne("name", "foo")
-var filter3 = rel.Gt("score", 80)
-var filter4 = rel.Lt("avg", 10)
+var filter1 = Eq("id", 1)
+var filter2 = Ne("name", "foo")
+var filter3 = Gt("score", 80)
+var filter4 = Lt("avg", 10)
 
 func TestFilterQuery_None(t *testing.T) {
-	assert.True(t, rel.FilterQuery{}.None())
-	assert.True(t, rel.And().None())
-	assert.True(t, rel.Not().None())
+	assert.True(t, FilterQuery{}.None())
+	assert.True(t, And().None())
+	assert.True(t, Not().None())
 
-	assert.False(t, rel.And(filter1).None())
-	assert.False(t, rel.And(filter1, filter2).None())
+	assert.False(t, And(filter1).None())
+	assert.False(t, And(filter1, filter2).None())
 	assert.False(t, filter1.None())
 }
 
 func TestFilterQuery_And(t *testing.T) {
 	tests := []struct {
 		Case      string
-		Operation rel.FilterQuery
-		Result    rel.FilterQuery
+		Operation FilterQuery
+		Result    FilterQuery
 	}{
 		{
-			`rel.FilterQuery{}.And()`,
-			rel.FilterQuery{}.And(),
-			rel.And(),
+			`FilterQuery{}.And()`,
+			FilterQuery{}.And(),
+			And(),
 		},
 		{
-			`rel.FilterQuery{}.And(filter1)`,
-			rel.FilterQuery{}.And(filter1),
+			`FilterQuery{}.And(filter1)`,
+			FilterQuery{}.And(filter1),
 			filter1,
 		},
 		{
-			`rel.FilterQuery{}.And(filter1).And()`,
-			rel.FilterQuery{}.And(filter1).And(),
+			`FilterQuery{}.And(filter1).And()`,
+			FilterQuery{}.And(filter1).And(),
 			filter1,
 		},
 		{
-			`rel.FilterQuery{}.And(filter1, filter2)`,
-			rel.FilterQuery{}.And(filter1, filter2),
-			rel.And(filter1, filter2),
+			`FilterQuery{}.And(filter1, filter2)`,
+			FilterQuery{}.And(filter1, filter2),
+			And(filter1, filter2),
 		},
 		{
-			`rel.FilterQuery{}.And(filter1, filter2).And()`,
-			rel.FilterQuery{}.And(filter1, filter2).And(),
-			rel.And(filter1, filter2),
+			`FilterQuery{}.And(filter1, filter2).And()`,
+			FilterQuery{}.And(filter1, filter2).And(),
+			And(filter1, filter2),
 		},
 		{
-			`rel.FilterQuery{}.And(filter1, filter2, filter3)`,
-			rel.FilterQuery{}.And(filter1, filter2, filter3),
-			rel.And(filter1, filter2, filter3),
+			`FilterQuery{}.And(filter1, filter2, filter3)`,
+			FilterQuery{}.And(filter1, filter2, filter3),
+			And(filter1, filter2, filter3),
 		},
 		{
-			`rel.FilterQuery{}.And(filter1, filter2, filter3).And()`,
-			rel.FilterQuery{}.And(filter1, filter2, filter3).And(),
-			rel.And(filter1, filter2, filter3),
+			`FilterQuery{}.And(filter1, filter2, filter3).And()`,
+			FilterQuery{}.And(filter1, filter2, filter3).And(),
+			And(filter1, filter2, filter3),
 		},
 		{
 			`filter1.And(filter2)`,
 			filter1.And(filter2),
-			rel.And(filter1, filter2),
+			And(filter1, filter2),
 		},
 		{
 			`filter1.And(filter2).And()`,
 			filter1.And(filter2).And(),
-			rel.And(filter1, filter2),
+			And(filter1, filter2),
 		},
 		{
 			`filter1.And(filter2).And(filter3)`,
 			filter1.And(filter2).And(filter3),
-			rel.And(filter1, filter2, filter3),
+			And(filter1, filter2, filter3),
 		},
 		{
 			`filter1.And(filter2).And(filter3).And()`,
 			filter1.And(filter2).And(filter3).And(),
-			rel.And(filter1, filter2, filter3),
+			And(filter1, filter2, filter3),
 		},
 	}
 
@@ -161,63 +160,63 @@ func TestFilterQuery_And(t *testing.T) {
 func TestFilterQuery_Or(t *testing.T) {
 	tests := []struct {
 		Case      string
-		Operation rel.FilterQuery
-		Result    rel.FilterQuery
+		Operation FilterQuery
+		Result    FilterQuery
 	}{
 		{
-			`rel.FilterQuery{}.Or()`,
-			rel.FilterQuery{}.Or(),
-			rel.Or(),
+			`FilterQuery{}.Or()`,
+			FilterQuery{}.Or(),
+			Or(),
 		},
 		{
-			`rel.FilterQuery{}.Or(filter1)`,
-			rel.FilterQuery{}.Or(filter1),
+			`FilterQuery{}.Or(filter1)`,
+			FilterQuery{}.Or(filter1),
 			filter1,
 		},
 		{
-			`rel.FilterQuery{}.Or(filter1).Or()`,
-			rel.FilterQuery{}.Or(filter1).Or(),
+			`FilterQuery{}.Or(filter1).Or()`,
+			FilterQuery{}.Or(filter1).Or(),
 			filter1,
 		},
 		{
-			`rel.FilterQuery{}.Or(filter1, filter2)`,
-			rel.FilterQuery{}.Or(filter1, filter2),
-			rel.Or(filter1, filter2),
+			`FilterQuery{}.Or(filter1, filter2)`,
+			FilterQuery{}.Or(filter1, filter2),
+			Or(filter1, filter2),
 		},
 		{
-			`rel.FilterQuery{}.Or(filter1, filter2).Or()`,
-			rel.FilterQuery{}.Or(filter1, filter2).Or(),
-			rel.Or(filter1, filter2),
+			`FilterQuery{}.Or(filter1, filter2).Or()`,
+			FilterQuery{}.Or(filter1, filter2).Or(),
+			Or(filter1, filter2),
 		},
 		{
-			`rel.FilterQuery{}.Or(filter1, filter2, filter3)`,
-			rel.FilterQuery{}.Or(filter1, filter2, filter3),
-			rel.Or(filter1, filter2, filter3),
+			`FilterQuery{}.Or(filter1, filter2, filter3)`,
+			FilterQuery{}.Or(filter1, filter2, filter3),
+			Or(filter1, filter2, filter3),
 		},
 		{
-			`rel.FilterQuery{}.Or(filter1, filter2, filter3).Or()`,
-			rel.FilterQuery{}.Or(filter1, filter2, filter3).Or(),
-			rel.Or(filter1, filter2, filter3),
+			`FilterQuery{}.Or(filter1, filter2, filter3).Or()`,
+			FilterQuery{}.Or(filter1, filter2, filter3).Or(),
+			Or(filter1, filter2, filter3),
 		},
 		{
 			`filter1.Or(filter2)`,
 			filter1.Or(filter2),
-			rel.Or(filter1, filter2),
+			Or(filter1, filter2),
 		},
 		{
 			`filter1.Or(filter2).Or()`,
 			filter1.Or(filter2).Or(),
-			rel.Or(filter1, filter2),
+			Or(filter1, filter2),
 		},
 		{
 			`filter1.Or(filter2).Or(filter3)`,
 			filter1.Or(filter2).Or(filter3),
-			rel.Or(filter1, filter2, filter3),
+			Or(filter1, filter2, filter3),
 		},
 		{
 			`filter1.Or(filter2).Or(filter3).Or()`,
 			filter1.Or(filter2).Or(filter3).Or(),
-			rel.Or(filter1, filter2, filter3),
+			Or(filter1, filter2, filter3),
 		},
 	}
 
@@ -231,68 +230,68 @@ func TestFilterQuery_Or(t *testing.T) {
 func TestAnd(t *testing.T) {
 	tests := []struct {
 		Case      string
-		Operation rel.FilterQuery
-		Result    rel.FilterQuery
+		Operation FilterQuery
+		Result    FilterQuery
 	}{
 		{
-			`rel.And()`,
-			rel.And(),
-			rel.FilterQuery{Type: rel.FilterAndOp},
+			`And()`,
+			And(),
+			FilterQuery{Type: FilterAndOp},
 		},
 		{
-			`rel.And(filter1)`,
-			rel.And(filter1),
+			`And(filter1)`,
+			And(filter1),
 			filter1,
 		},
 		{
-			`rel.And(filter1, filter2)`,
-			rel.And(filter1, filter2),
-			rel.FilterQuery{
-				Type:  rel.FilterAndOp,
-				Inner: []rel.FilterQuery{filter1, filter2},
+			`And(filter1, filter2)`,
+			And(filter1, filter2),
+			FilterQuery{
+				Type:  FilterAndOp,
+				Inner: []FilterQuery{filter1, filter2},
 			},
 		},
 		{
-			`rel.And(filter1, rel.Or(filter2, filter3))`,
-			rel.And(filter1, rel.Or(filter2, filter3)),
-			rel.FilterQuery{
-				Type: rel.FilterAndOp,
-				Inner: []rel.FilterQuery{
+			`And(filter1, Or(filter2, filter3))`,
+			And(filter1, Or(filter2, filter3)),
+			FilterQuery{
+				Type: FilterAndOp,
+				Inner: []FilterQuery{
 					filter1,
 					{
-						Type:  rel.FilterOrOp,
-						Inner: []rel.FilterQuery{filter2, filter3},
+						Type:  FilterOrOp,
+						Inner: []FilterQuery{filter2, filter3},
 					},
 				},
 			},
 		},
 		{
-			`rel.And(rel.Or(filter1, filter2), filter3)`,
-			rel.And(rel.Or(filter1, filter2), filter3),
-			rel.FilterQuery{
-				Type: rel.FilterAndOp,
-				Inner: []rel.FilterQuery{
+			`And(Or(filter1, filter2), filter3)`,
+			And(Or(filter1, filter2), filter3),
+			FilterQuery{
+				Type: FilterAndOp,
+				Inner: []FilterQuery{
 					{
-						Type:  rel.FilterOrOp,
-						Inner: []rel.FilterQuery{filter1, filter2},
+						Type:  FilterOrOp,
+						Inner: []FilterQuery{filter1, filter2},
 					},
 					filter3,
 				},
 			},
 		},
 		{
-			`rel.And(rel.Or(filter1, filter2), rel.Or(filter3, filter4))`,
-			rel.And(rel.Or(filter1, filter2), rel.Or(filter3, filter4)),
-			rel.FilterQuery{
-				Type: rel.FilterAndOp,
-				Inner: []rel.FilterQuery{
+			`And(Or(filter1, filter2), Or(filter3, filter4))`,
+			And(Or(filter1, filter2), Or(filter3, filter4)),
+			FilterQuery{
+				Type: FilterAndOp,
+				Inner: []FilterQuery{
 					{
-						Type:  rel.FilterOrOp,
-						Inner: []rel.FilterQuery{filter1, filter2},
+						Type:  FilterOrOp,
+						Inner: []FilterQuery{filter1, filter2},
 					},
 					{
-						Type:  rel.FilterOrOp,
-						Inner: []rel.FilterQuery{filter3, filter4},
+						Type:  FilterOrOp,
+						Inner: []FilterQuery{filter3, filter4},
 					},
 				},
 			},
@@ -309,68 +308,68 @@ func TestAnd(t *testing.T) {
 func TestOr(t *testing.T) {
 	tests := []struct {
 		Case      string
-		Operation rel.FilterQuery
-		Result    rel.FilterQuery
+		Operation FilterQuery
+		Result    FilterQuery
 	}{
 		{
-			`rel.Or()`,
-			rel.Or(),
-			rel.FilterQuery{Type: rel.FilterOrOp},
+			`Or()`,
+			Or(),
+			FilterQuery{Type: FilterOrOp},
 		},
 		{
-			`rel.Or(filter1)`,
-			rel.Or(filter1),
+			`Or(filter1)`,
+			Or(filter1),
 			filter1,
 		},
 		{
-			`rel.Or(filter1, filter2)`,
-			rel.Or(filter1, filter2),
-			rel.FilterQuery{
-				Type:  rel.FilterOrOp,
-				Inner: []rel.FilterQuery{filter1, filter2},
+			`Or(filter1, filter2)`,
+			Or(filter1, filter2),
+			FilterQuery{
+				Type:  FilterOrOp,
+				Inner: []FilterQuery{filter1, filter2},
 			},
 		},
 		{
-			`rel.Or(filter1, rel.And(filter2, filter3))`,
-			rel.Or(filter1, rel.And(filter2, filter3)),
-			rel.FilterQuery{
-				Type: rel.FilterOrOp,
-				Inner: []rel.FilterQuery{
+			`Or(filter1, And(filter2, filter3))`,
+			Or(filter1, And(filter2, filter3)),
+			FilterQuery{
+				Type: FilterOrOp,
+				Inner: []FilterQuery{
 					filter1,
 					{
-						Type:  rel.FilterAndOp,
-						Inner: []rel.FilterQuery{filter2, filter3},
+						Type:  FilterAndOp,
+						Inner: []FilterQuery{filter2, filter3},
 					},
 				},
 			},
 		},
 		{
-			`rel.Or(rel.And(filter1, filter2), filter3)`,
-			rel.Or(rel.And(filter1, filter2), filter3),
-			rel.FilterQuery{
-				Type: rel.FilterOrOp,
-				Inner: []rel.FilterQuery{
+			`Or(And(filter1, filter2), filter3)`,
+			Or(And(filter1, filter2), filter3),
+			FilterQuery{
+				Type: FilterOrOp,
+				Inner: []FilterQuery{
 					{
-						Type:  rel.FilterAndOp,
-						Inner: []rel.FilterQuery{filter1, filter2},
+						Type:  FilterAndOp,
+						Inner: []FilterQuery{filter1, filter2},
 					},
 					filter3,
 				},
 			},
 		},
 		{
-			`rel.Or(rel.And(filter1, filter2), rel.And(filter3, filter4))`,
-			rel.Or(rel.And(filter1, filter2), rel.And(filter3, filter4)),
-			rel.FilterQuery{
-				Type: rel.FilterOrOp,
-				Inner: []rel.FilterQuery{
+			`Or(And(filter1, filter2), And(filter3, filter4))`,
+			Or(And(filter1, filter2), And(filter3, filter4)),
+			FilterQuery{
+				Type: FilterOrOp,
+				Inner: []FilterQuery{
 					{
-						Type:  rel.FilterAndOp,
-						Inner: []rel.FilterQuery{filter1, filter2},
+						Type:  FilterAndOp,
+						Inner: []FilterQuery{filter1, filter2},
 					},
 					{
-						Type:  rel.FilterAndOp,
-						Inner: []rel.FilterQuery{filter3, filter4},
+						Type:  FilterAndOp,
+						Inner: []FilterQuery{filter3, filter4},
 					},
 				},
 			},
@@ -387,530 +386,572 @@ func TestOr(t *testing.T) {
 func TestFilterQuery_Not(t *testing.T) {
 	tests := []struct {
 		Case     string
-		Input    rel.FilterOp
-		Expected rel.FilterOp
+		Input    FilterOp
+		Expected FilterOp
 	}{
 		{
 			`Not Eq`,
-			rel.FilterEqOp,
-			rel.FilterNeOp,
+			FilterEqOp,
+			FilterNeOp,
 		},
 		{
 			`Not Lt`,
-			rel.FilterLtOp,
-			rel.FilterGteOp,
+			FilterLtOp,
+			FilterGteOp,
 		},
 		{
 			`Not Lte`,
-			rel.FilterLteOp,
-			rel.FilterGtOp,
+			FilterLteOp,
+			FilterGtOp,
 		},
 		{
 			`Not Gt`,
-			rel.FilterGtOp,
-			rel.FilterLteOp,
+			FilterGtOp,
+			FilterLteOp,
 		},
 		{
 			`Not Gte`,
-			rel.FilterGteOp,
-			rel.FilterLtOp,
+			FilterGteOp,
+			FilterLtOp,
 		},
 		{
 			`Not Nil`,
-			rel.FilterNilOp,
-			rel.FilterNotNilOp,
+			FilterNilOp,
+			FilterNotNilOp,
 		},
 		{
 			`Not In`,
-			rel.FilterInOp,
-			rel.FilterNinOp,
+			FilterInOp,
+			FilterNinOp,
 		},
 		{
 			`Not Like`,
-			rel.FilterLikeOp,
-			rel.FilterNotLikeOp,
+			FilterLikeOp,
+			FilterNotLikeOp,
 		},
 		{
 			`And Op`,
-			rel.FilterAndOp,
-			rel.FilterNotOp,
+			FilterAndOp,
+			FilterNotOp,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.Case, func(t *testing.T) {
-			assert.Equal(t, tt.Expected, rel.Not(rel.FilterQuery{Type: tt.Input}).Type)
+			assert.Equal(t, tt.Expected, Not(FilterQuery{Type: tt.Input}).Type)
 		})
 	}
 }
 
 func TestFilterQuery_AndEq(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterEqOp,
+				Type:  FilterEqOp,
 				Field: "field",
 				Value: "value",
 			},
 		},
-	}, rel.FilterQuery{}.AndEq("field", "value"))
+	}, FilterQuery{}.AndEq("field", "value"))
 }
 
 func TestFilterQuery_AndNe(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNeOp,
+				Type:  FilterNeOp,
 				Field: "field",
 				Value: "value",
 			},
 		},
-	}, rel.FilterQuery{}.AndNe("field", "value"))
+	}, FilterQuery{}.AndNe("field", "value"))
 }
 
 func TestFilterQuery_AndLt(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterLtOp,
+				Type:  FilterLtOp,
 				Field: "field",
 				Value: 10,
 			},
 		},
-	}, rel.FilterQuery{}.AndLt("field", 10))
+	}, FilterQuery{}.AndLt("field", 10))
 }
 
 func TestFilterQuery_AndLte(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterLteOp,
+				Type:  FilterLteOp,
 				Field: "field",
 				Value: 10,
 			},
 		},
-	}, rel.FilterQuery{}.AndLte("field", 10))
+	}, FilterQuery{}.AndLte("field", 10))
 }
 
 func TestFilterQuery_AndGt(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterGtOp,
+				Type:  FilterGtOp,
 				Field: "field",
 				Value: 10,
 			},
 		},
-	}, rel.FilterQuery{}.AndGt("field", 10))
+	}, FilterQuery{}.AndGt("field", 10))
 }
 
 func TestFilterQuery_AndGte(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterGteOp,
+				Type:  FilterGteOp,
 				Field: "field",
 				Value: 10,
 			},
 		},
-	}, rel.FilterQuery{}.AndGte("field", 10))
+	}, FilterQuery{}.AndGte("field", 10))
 }
 
 func TestFilterQuery_AndNil(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNilOp,
+				Type:  FilterNilOp,
 				Field: "field",
 			},
 		},
-	}, rel.FilterQuery{}.AndNil("field"))
+	}, FilterQuery{}.AndNil("field"))
 }
 
 func TestFilterQuery_AndNotNil(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNotNilOp,
+				Type:  FilterNotNilOp,
 				Field: "field",
 			},
 		},
-	}, rel.FilterQuery{}.AndNotNil("field"))
+	}, FilterQuery{}.AndNotNil("field"))
 }
 
 func TestFilterQuery_AndIn(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterInOp,
+				Type:  FilterInOp,
 				Field: "field",
 				Value: []interface{}{"value1", "value2"},
 			},
 		},
-	}, rel.FilterQuery{}.AndIn("field", "value1", "value2"))
+	}, FilterQuery{}.AndIn("field", "value1", "value2"))
 }
 
 func TestFilterQuery_AndNin(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNinOp,
+				Type:  FilterNinOp,
 				Field: "field",
 				Value: []interface{}{"value1", "value2"},
 			},
 		},
-	}, rel.FilterQuery{}.AndNin("field", "value1", "value2"))
+	}, FilterQuery{}.AndNin("field", "value1", "value2"))
 }
 
 func TestFilterQuery_AndLike(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterLikeOp,
+				Type:  FilterLikeOp,
 				Field: "field",
 				Value: "%expr%",
 			},
 		},
-	}, rel.FilterQuery{}.AndLike("field", "%expr%"))
+	}, FilterQuery{}.AndLike("field", "%expr%"))
 }
 
 func TestFilterQuery_AndNotLike(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNotLikeOp,
+				Type:  FilterNotLikeOp,
 				Field: "field",
 				Value: "%expr%",
 			},
 		},
-	}, rel.FilterQuery{}.AndNotLike("field", "%expr%"))
+	}, FilterQuery{}.AndNotLike("field", "%expr%"))
 }
 
 func TestFilterQuery_AndFragment(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterFragmentOp,
+				Type:  FilterFragmentOp,
 				Field: "expr",
 				Value: []interface{}{"value"},
 			},
 		},
-	}, rel.FilterQuery{}.AndFragment("expr", "value"))
+	}, FilterQuery{}.AndFragment("expr", "value"))
 }
 
 func TestFilterQuery_OrEq(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterEqOp,
+				Type:  FilterEqOp,
 				Field: "field",
 				Value: "value",
 			},
 		},
-	}, rel.FilterQuery{}.OrEq("field", "value"))
+	}, FilterQuery{}.OrEq("field", "value"))
 }
 
 func TestFilterQuery_OrNe(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNeOp,
+				Type:  FilterNeOp,
 				Field: "field",
 				Value: "value",
 			},
 		},
-	}, rel.FilterQuery{}.OrNe("field", "value"))
+	}, FilterQuery{}.OrNe("field", "value"))
 }
 
 func TestFilterQuery_OrLt(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterLtOp,
+				Type:  FilterLtOp,
 				Field: "field",
 				Value: 10,
 			},
 		},
-	}, rel.FilterQuery{}.OrLt("field", 10))
+	}, FilterQuery{}.OrLt("field", 10))
 }
 
 func TestFilterQuery_OrLte(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterLteOp,
+				Type:  FilterLteOp,
 				Field: "field",
 				Value: 10,
 			},
 		},
-	}, rel.FilterQuery{}.OrLte("field", 10))
+	}, FilterQuery{}.OrLte("field", 10))
 }
 
 func TestFilterQuery_OrGt(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterGtOp,
+				Type:  FilterGtOp,
 				Field: "field",
 				Value: 10,
 			},
 		},
-	}, rel.FilterQuery{}.OrGt("field", 10))
+	}, FilterQuery{}.OrGt("field", 10))
 }
 
 func TestFilterQuery_OrGte(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterGteOp,
+				Type:  FilterGteOp,
 				Field: "field",
 				Value: 10,
 			},
 		},
-	}, rel.FilterQuery{}.OrGte("field", 10))
+	}, FilterQuery{}.OrGte("field", 10))
 }
 
 func TestFilterQuery_OrNil(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNilOp,
+				Type:  FilterNilOp,
 				Field: "field",
 			},
 		},
-	}, rel.FilterQuery{}.OrNil("field"))
+	}, FilterQuery{}.OrNil("field"))
 }
 
 func TestFilterQuery_OrNotNil(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNotNilOp,
+				Type:  FilterNotNilOp,
 				Field: "field",
 			},
 		},
-	}, rel.FilterQuery{}.OrNotNil("field"))
+	}, FilterQuery{}.OrNotNil("field"))
 }
 
 func TestFilterQuery_OrIn(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterInOp,
+				Type:  FilterInOp,
 				Field: "field",
 				Value: []interface{}{"value1", "value2"},
 			},
 		},
-	}, rel.FilterQuery{}.OrIn("field", "value1", "value2"))
+	}, FilterQuery{}.OrIn("field", "value1", "value2"))
 }
 
 func TestFilterQuery_OrNin(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNinOp,
+				Type:  FilterNinOp,
 				Field: "field",
 				Value: []interface{}{"value1", "value2"},
 			},
 		},
-	}, rel.FilterQuery{}.OrNin("field", "value1", "value2"))
+	}, FilterQuery{}.OrNin("field", "value1", "value2"))
 }
 
 func TestFilterQuery_OrLike(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterLikeOp,
+				Type:  FilterLikeOp,
 				Field: "field",
 				Value: "%expr%",
 			},
 		},
-	}, rel.FilterQuery{}.OrLike("field", "%expr%"))
+	}, FilterQuery{}.OrLike("field", "%expr%"))
 }
 
 func TestFilterQuery_OrNotLike(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterNotLikeOp,
+				Type:  FilterNotLikeOp,
 				Field: "field",
 				Value: "%expr%",
 			},
 		},
-	}, rel.FilterQuery{}.OrNotLike("field", "%expr%"))
+	}, FilterQuery{}.OrNotLike("field", "%expr%"))
 }
 
 func TestFilterQuery_OrFragment(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type: rel.FilterOrOp,
-		Inner: []rel.FilterQuery{
+	assert.Equal(t, FilterQuery{
+		Type: FilterOrOp,
+		Inner: []FilterQuery{
 			{
-				Type:  rel.FilterFragmentOp,
+				Type:  FilterFragmentOp,
 				Field: "expr",
 				Value: []interface{}{"value"},
 			},
 		},
-	}, rel.FilterQuery{}.OrFragment("expr", "value"))
+	}, FilterQuery{}.OrFragment("expr", "value"))
 }
 
 func TestEq(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterEqOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterEqOp,
 		Field: "field",
 		Value: "value",
-	}, rel.Eq("field", "value"))
+	}, Eq("field", "value"))
 }
 
-func Ne(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterNeOp,
+func TestNe(t *testing.T) {
+	assert.Equal(t, FilterQuery{
+		Type:  FilterNeOp,
 		Field: "field",
 		Value: "value",
-	}, rel.Ne("field", "value"))
+	}, Ne("field", "value"))
 }
 
 func TestLt(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterLtOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterLtOp,
 		Field: "field",
 		Value: 10,
-	}, rel.Lt("field", 10))
+	}, Lt("field", 10))
 }
 
 func TestLte(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterLteOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterLteOp,
 		Field: "field",
 		Value: 10,
-	}, rel.Lte("field", 10))
+	}, Lte("field", 10))
 }
 
 func TestFilterQueryGt(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterGtOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterGtOp,
 		Field: "field",
 		Value: 10,
-	}, rel.Gt("field", 10))
+	}, Gt("field", 10))
 }
 
 func TestGte(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterGteOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterGteOp,
 		Field: "field",
 		Value: 10,
-	}, rel.Gte("field", 10))
+	}, Gte("field", 10))
 }
 
 func TestNil(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterNilOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterNilOp,
 		Field: "field",
-	}, rel.Nil("field"))
+	}, Nil("field"))
 }
 
 func TestNotNil(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterNotNilOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterNotNilOp,
 		Field: "field",
-	}, rel.NotNil("field"))
+	}, NotNil("field"))
 }
 
 func TestIn(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterInOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterInOp,
 		Field: "field",
 		Value: []interface{}{"value1", "value2"},
-	}, rel.In("field", "value1", "value2"))
+	}, In("field", "value1", "value2"))
 }
 
 func TestInInt(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterInOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterInOp,
 		Field: "field",
 		Value: []interface{}{1, 2},
-	}, rel.InInt("field", []int{1, 2}))
+	}, InInt("field", []int{1, 2}))
 }
 
 func TestInUint(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterInOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterInOp,
 		Field: "field",
 		Value: []interface{}{uint(1), uint(2)},
-	}, rel.InUint("field", []uint{1, 2}))
+	}, InUint("field", []uint{1, 2}))
 }
 
 func TestInString(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterInOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterInOp,
 		Field: "field",
 		Value: []interface{}{"1", "2"},
-	}, rel.InString("field", []string{"1", "2"}))
+	}, InString("field", []string{"1", "2"}))
 }
 
 func TestNin(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterNinOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterNinOp,
 		Field: "field",
 		Value: []interface{}{"value1", "value2"},
-	}, rel.Nin("field", "value1", "value2"))
+	}, Nin("field", "value1", "value2"))
 }
 
 func TestNinInt(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterNinOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterNinOp,
 		Field: "field",
 		Value: []interface{}{1, 2},
-	}, rel.NinInt("field", []int{1, 2}))
+	}, NinInt("field", []int{1, 2}))
 }
 
 func TestNinUint(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterNinOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterNinOp,
 		Field: "field",
 		Value: []interface{}{uint(1), uint(2)},
-	}, rel.NinUint("field", []uint{1, 2}))
+	}, NinUint("field", []uint{1, 2}))
 }
 
 func TestNinString(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterNinOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterNinOp,
 		Field: "field",
 		Value: []interface{}{"1", "2"},
-	}, rel.NinString("field", []string{"1", "2"}))
+	}, NinString("field", []string{"1", "2"}))
 }
 
 func TestLike(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterLikeOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterLikeOp,
 		Field: "field",
 		Value: "%expr%",
-	}, rel.Like("field", "%expr%"))
+	}, Like("field", "%expr%"))
 }
 
 func TestNotLike(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterNotLikeOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterNotLikeOp,
 		Field: "field",
 		Value: "%expr%",
-	}, rel.NotLike("field", "%expr%"))
+	}, NotLike("field", "%expr%"))
 }
 
 func TestFilterFragment(t *testing.T) {
-	assert.Equal(t, rel.FilterQuery{
-		Type:  rel.FilterFragmentOp,
+	assert.Equal(t, FilterQuery{
+		Type:  FilterFragmentOp,
 		Field: "expr",
 		Value: []interface{}{"value"},
-	}, rel.FilterFragment("expr", "value"))
+	}, FilterFragment("expr", "value"))
+}
+
+func TestFilterDocument(t *testing.T) {
+	var (
+		user = User{ID: 1}
+		doc  = NewDocument(&user)
+	)
+
+	assert.Equal(t, Eq("id", 1), filterDocument(doc))
+}
+
+func TestFilterDocument_compositePrimaryKey(t *testing.T) {
+	var (
+		userRole = UserRole{UserID: 1, RoleID: 2}
+		doc      = NewDocument(&userRole)
+	)
+
+	assert.Equal(t, Eq("user_id", 1).AndEq("role_id", 2), filterDocument(doc))
+}
+
+func TestFilterCollection(t *testing.T) {
+	var (
+		users = []User{
+			{ID: 1},
+			{ID: 2},
+		}
+		col = NewCollection(&users)
+	)
+
+	assert.Equal(t, In("id", 1, 2), filterCollection(col))
+}
+
+func TestFilterCollection_compositePrimaryKey(t *testing.T) {
+	var (
+		userRoles = []UserRole{
+			{UserID: 1, RoleID: 2},
+			{UserID: 3, RoleID: 4},
+		}
+		col = NewCollection(&userRoles)
+	)
+
+	assert.Equal(t, Or(Eq("user_id", 1).AndEq("role_id", 2), Eq("user_id", 3).AndEq("role_id", 4)), filterCollection(col))
 }

--- a/iterator.go
+++ b/iterator.go
@@ -16,25 +16,37 @@ type IteratorOption interface {
 	apply(*iterator)
 }
 
-// BatchSize specifies the size of iterator batch. Defaults to 1000.
-type BatchSize int
+type batchSize int
 
-func (bs BatchSize) apply(i *iterator) {
+func (bs batchSize) apply(i *iterator) {
 	i.batchSize = int(bs)
 }
 
-// Start specfies the primary value to start from (inclusive).
-type Start int
+// BatchSize specifies the size of iterator batch. Defaults to 1000.
+func BatchSize(size int) IteratorOption {
+	return batchSize(size)
+}
 
-func (s Start) apply(i *iterator) {
-	i.start = []interface{}{int(s)}
+type start []interface{}
+
+func (s start) apply(i *iterator) {
+	i.start = s
+}
+
+// Start specfies the primary value to start from (inclusive).
+func Start(id ...interface{}) IteratorOption {
+	return start(id)
+}
+
+type finish []interface{}
+
+func (f finish) apply(i *iterator) {
+	i.finish = f
 }
 
 // Finish specfies the primary value to finish at (inclusive).
-type Finish int
-
-func (f Finish) apply(i *iterator) {
-	i.finish = []interface{}{int(f)}
+func Finish(id ...interface{}) IteratorOption {
+	return finish(id)
 }
 
 type iterator struct {
@@ -113,11 +125,11 @@ func (i *iterator) init(record interface{}) {
 		i.query.Table = doc.Table()
 	}
 
-	if i.start != nil {
+	if len(i.start) > 0 {
 		i.query = i.query.Where(filterDocumentPrimary(doc.PrimaryFields(), i.start, FilterGteOp))
 	}
 
-	if i.finish != nil {
+	if len(i.finish) > 0 {
 		i.query = i.query.Where(filterDocumentPrimary(doc.PrimaryFields(), i.finish, FilterLteOp))
 	}
 

--- a/iterator.go
+++ b/iterator.go
@@ -27,20 +27,20 @@ func (bs BatchSize) apply(i *iterator) {
 type Start int
 
 func (s Start) apply(i *iterator) {
-	i.start = int(s)
+	i.start = []interface{}{s}
 }
 
 // Finish specfies the primary value to finish at (inclusive).
 type Finish int
 
 func (f Finish) apply(i *iterator) {
-	i.finish = int(f)
+	i.finish = []interface{}{f}
 }
 
 type iterator struct {
 	ctx       context.Context
-	start     interface{}
-	finish    interface{}
+	start     []interface{}
+	finish    []interface{}
 	batchSize int
 	current   int
 	query     Query
@@ -114,14 +114,14 @@ func (i *iterator) init(record interface{}) {
 	}
 
 	if i.start != nil {
-		i.query = i.query.Where(Gte(doc.PrimaryField(), i.start))
+		i.query = i.query.Where(filterDocumentPrimary(doc.PrimaryField(), i.start, FilterGteOp))
 	}
 
 	if i.finish != nil {
-		i.query = i.query.Where(Lte(doc.PrimaryField(), i.finish))
+		i.query = i.query.Where(filterDocumentPrimary(doc.PrimaryField(), i.finish, FilterLteOp))
 	}
 
-	i.query = i.query.SortAsc(doc.PrimaryField())
+	i.query = i.query.SortAsc(doc.PrimaryField()...)
 }
 
 func newIterator(ctx context.Context, adapter Adapter, query Query, options []IteratorOption) Iterator {

--- a/iterator.go
+++ b/iterator.go
@@ -27,14 +27,14 @@ func (bs BatchSize) apply(i *iterator) {
 type Start int
 
 func (s Start) apply(i *iterator) {
-	i.start = []interface{}{s}
+	i.start = []interface{}{int(s)}
 }
 
 // Finish specfies the primary value to finish at (inclusive).
 type Finish int
 
 func (f Finish) apply(i *iterator) {
-	i.finish = []interface{}{f}
+	i.finish = []interface{}{int(f)}
 }
 
 type iterator struct {
@@ -114,14 +114,14 @@ func (i *iterator) init(record interface{}) {
 	}
 
 	if i.start != nil {
-		i.query = i.query.Where(filterDocumentPrimary(doc.PrimaryField(), i.start, FilterGteOp))
+		i.query = i.query.Where(filterDocumentPrimary(doc.PrimaryFields(), i.start, FilterGteOp))
 	}
 
 	if i.finish != nil {
-		i.query = i.query.Where(filterDocumentPrimary(doc.PrimaryField(), i.finish, FilterLteOp))
+		i.query = i.query.Where(filterDocumentPrimary(doc.PrimaryFields(), i.finish, FilterLteOp))
 	}
 
-	i.query = i.query.SortAsc(doc.PrimaryField()...)
+	i.query = i.query.SortAsc(doc.PrimaryFields()...)
 }
 
 func newIterator(ctx context.Context, adapter Adapter, query Query, options []IteratorOption) Iterator {

--- a/map.go
+++ b/map.go
@@ -13,9 +13,13 @@ type Map map[string]interface{}
 
 // Apply mutation.
 func (m Map) Apply(doc *Document, mutation *Mutation) {
+	if len(doc.PrimaryField()) != 1 {
+		panic("rel: map mutator only supports 1 primary key")
+	}
+
 	var (
-		pField = doc.PrimaryField()
-		pValue = doc.PrimaryValue()
+		pField = doc.PrimaryField()[0]
+		pValue = doc.PrimaryValue()[0]
 	)
 
 	for field, value := range m {
@@ -73,9 +77,16 @@ func applyMaps(maps []Map, assoc Association) ([]Mutation, []interface{}) {
 		deletedIDs []interface{}
 		muts       = make([]Mutation, len(maps))
 		col, _     = assoc.Collection()
-		pField     = col.PrimaryField()
-		pIndex     = make(map[interface{}]int)
-		pValues    = col.PrimaryValue().([]interface{})
+	)
+
+	if len(col.PrimaryField()) != 1 {
+		panic("rel: map mutator only supports assoc with 1 primary key")
+	}
+
+	var (
+		pField  = col.PrimaryField()[0]
+		pIndex  = make(map[interface{}]int)
+		pValues = col.PrimaryValue()[0].([]interface{})
 	)
 
 	for i, v := range pValues {

--- a/map.go
+++ b/map.go
@@ -13,13 +13,9 @@ type Map map[string]interface{}
 
 // Apply mutation.
 func (m Map) Apply(doc *Document, mutation *Mutation) {
-	if len(doc.PrimaryField()) != 1 {
-		panic("rel: map mutator only supports 1 primary key")
-	}
-
 	var (
-		pField = doc.PrimaryField()[0]
-		pValue = doc.PrimaryValue()[0]
+		pField = doc.PrimaryField()
+		pValue = doc.PrimaryValue()
 	)
 
 	for field, value := range m {
@@ -79,14 +75,10 @@ func applyMaps(maps []Map, assoc Association) ([]Mutation, []interface{}) {
 		col, _     = assoc.Collection()
 	)
 
-	if len(col.PrimaryField()) != 1 {
-		panic("rel: map mutator only supports assoc with 1 primary key")
-	}
-
 	var (
-		pField  = col.PrimaryField()[0]
+		pField  = col.PrimaryField()
 		pIndex  = make(map[interface{}]int)
-		pValues = col.PrimaryValue()[0].([]interface{})
+		pValues = col.PrimaryValue().([]interface{})
 	)
 
 	for i, v := range pValues {

--- a/mutation.go
+++ b/mutation.go
@@ -42,7 +42,7 @@ func Apply(doc *Document, mutators ...Mutator) Mutation {
 // AssocMutation represents mutation for association.
 type AssocMutation struct {
 	Mutations  []Mutation
-	DeletedIDs []interface{}
+	DeletedIDs []interface{} // This is array of single id, and doesn't support composite primary key.
 }
 
 // Mutation represents value to be inserted or updated to database.

--- a/rel_test.go
+++ b/rel_test.go
@@ -12,6 +12,7 @@ type User struct {
 	Age          int
 	Transactions []Transaction `ref:"id" fk:"user_id"`
 	Address      Address
+	UserRoles    []UserRole
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
 }
@@ -54,4 +55,15 @@ type Address struct {
 type Owner struct {
 	User   *User
 	UserID *int
+}
+
+type Role struct {
+	ID        int
+	Name      string
+	UserRoles []UserRole
+}
+
+type UserRole struct {
+	UserID int `db:",primary"`
+	RoleID int `db:",primary"`
 }

--- a/repository.go
+++ b/repository.go
@@ -279,7 +279,9 @@ func (r repository) insert(cw contextWrapper, doc *Document, mutation Mutation) 
 	}
 
 	if mutation.Reload {
-		var filter = filterDocument(doc)
+		var (
+			filter = filterDocument(doc)
+		)
 
 		// fetch record
 		if err := r.find(cw, doc, queriers.Where(filter)); err != nil {

--- a/repository.go
+++ b/repository.go
@@ -457,7 +457,7 @@ func (r repository) saveBelongsTo(cw contextWrapper, doc *Document, mutation *Mu
 		)
 
 		if loaded {
-			filter, err := r.buildBelongsToFilter(assoc)
+			filter, err := filterBelongsTo(assoc)
 			if err != nil {
 				return err
 			}
@@ -483,24 +483,6 @@ func (r repository) saveBelongsTo(cw contextWrapper, doc *Document, mutation *Mu
 	return nil
 }
 
-func (r repository) buildBelongsToFilter(assoc Association) (FilterQuery, error) {
-	var (
-		rValue = assoc.ReferenceValue()
-		fValue = assoc.ForeignValue()
-		filter = Eq(assoc.ForeignField(), fValue)
-	)
-
-	if rValue != fValue {
-		return filter, ConstraintError{
-			Key:  assoc.ReferenceField(),
-			Type: ForeignKeyConstraint,
-			Err:  errors.New("rel: inconsistent belongs to ref and fk"),
-		}
-	}
-
-	return filter, nil
-}
-
 // TODO: suppprt deletion
 func (r repository) saveHasOne(cw contextWrapper, doc *Document, mutation *Mutation) error {
 	for _, field := range doc.HasOne() {
@@ -516,7 +498,7 @@ func (r repository) saveHasOne(cw contextWrapper, doc *Document, mutation *Mutat
 		)
 
 		if loaded {
-			filter, err := r.buildHasOneFilter(assoc, assocDoc)
+			filter, err := filterHasOne(assoc, assocDoc)
 			if err != nil {
 				return err
 			}
@@ -540,25 +522,6 @@ func (r repository) saveHasOne(cw contextWrapper, doc *Document, mutation *Mutat
 	}
 
 	return nil
-}
-
-func (r repository) buildHasOneFilter(assoc Association, asssocDoc *Document) (FilterQuery, error) {
-	var (
-		fField = assoc.ForeignField()
-		fValue = assoc.ForeignValue()
-		rValue = assoc.ReferenceValue()
-		filter = filterDocument(asssocDoc).AndEq(fField, rValue)
-	)
-
-	if rValue != fValue {
-		return filter, ConstraintError{
-			Key:  fField,
-			Type: ForeignKeyConstraint,
-			Err:  errors.New("rel: inconsistent has one ref and fk"),
-		}
-	}
-
-	return filter, nil
 }
 
 // saveHasMany expects has many mutation to be ordered the same as the recrods in collection.
@@ -748,7 +711,7 @@ func (r repository) deleteBelongsTo(cw contextWrapper, doc *Document, cascade Ca
 		)
 
 		if loaded {
-			filter, err := r.buildBelongsToFilter(assoc)
+			filter, err := filterBelongsTo(assoc)
 			if err != nil {
 				return err
 			}
@@ -770,7 +733,7 @@ func (r repository) deleteHasOne(cw contextWrapper, doc *Document, cascade Casca
 		)
 
 		if loaded {
-			filter, err := r.buildHasOneFilter(assoc, assocDoc)
+			filter, err := filterHasOne(assoc, assocDoc)
 			if err != nil {
 				return err
 			}

--- a/repository_test.go
+++ b/repository_test.go
@@ -453,6 +453,59 @@ func TestRepository_MustFindAndCountAll(t *testing.T) {
 
 func TestRepository_Insert(t *testing.T) {
 	var (
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+		user    = User{
+			Name: "name",
+		}
+		mutates = map[string]Mutate{
+			"name":       Set("name", "name"),
+			"age":        Set("age", 0),
+			"created_at": Set("created_at", now()),
+			"updated_at": Set("updated_at", now()),
+		}
+	)
+
+	adapter.On("Insert", From("users"), mutates).Return(1, nil).Once()
+
+	assert.Nil(t, repo.Insert(context.TODO(), &user))
+	assert.Equal(t, User{
+		ID:        1,
+		Name:      "name",
+		CreatedAt: now(),
+		UpdatedAt: now(),
+	}, user)
+
+	adapter.AssertExpectations(t)
+}
+
+func TestRepository_Insert_compositePrimaryFields(t *testing.T) {
+	var (
+		adapter  = &testAdapter{}
+		repo     = New(adapter)
+		userRole = UserRole{
+			UserID: 1,
+			RoleID: 2,
+		}
+		mutates = map[string]Mutate{
+			"user_id": Set("user_id", 1),
+			"role_id": Set("role_id", 2),
+		}
+	)
+
+	adapter.On("Insert", From("user_roles"), mutates).Return(0, nil).Once()
+
+	assert.Nil(t, repo.Insert(context.TODO(), &userRole))
+	assert.Equal(t, UserRole{
+		UserID: 1,
+		RoleID: 2,
+	}, userRole)
+
+	adapter.AssertExpectations(t)
+}
+
+func TestRepository_Insert_sets(t *testing.T) {
+	var (
 		user     User
 		adapter  = &testAdapter{}
 		repo     = New(adapter)
@@ -908,6 +961,37 @@ func TestRepository_InsertAll(t *testing.T) {
 	adapter.AssertExpectations(t)
 }
 
+func TestRepository_InsertAll_compositePrimaryFields(t *testing.T) {
+	var (
+		userRoles = []UserRole{
+			{UserID: 1, RoleID: 2},
+			{UserID: 1, RoleID: 3},
+		}
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+		mutates = []map[string]Mutate{
+			{
+				"user_id": Set("user_id", 1),
+				"role_id": Set("role_id", 2),
+			},
+			{
+				"user_id": Set("user_id", 1),
+				"role_id": Set("role_id", 3),
+			},
+		}
+	)
+
+	adapter.On("InsertAll", From("user_roles"), mock.Anything, mutates).Return([]interface{}{0, 0}, nil).Once()
+
+	assert.Nil(t, repo.InsertAll(context.TODO(), &userRoles))
+	assert.Equal(t, []UserRole{
+		{UserID: 1, RoleID: 2},
+		{UserID: 1, RoleID: 3},
+	}, userRoles)
+
+	adapter.AssertExpectations(t)
+}
+
 func TestRepository_InsertAll_empty(t *testing.T) {
 	var (
 		users   []User
@@ -933,6 +1017,65 @@ func TestRepository_InsertAll_nothing(t *testing.T) {
 }
 
 func TestRepository_Update(t *testing.T) {
+	var (
+		adapter = &testAdapter{}
+		repo    = New(adapter)
+		user    = User{
+			ID:        1,
+			Name:      "name",
+			CreatedAt: now(),
+			UpdatedAt: now(),
+		}
+		mutates = map[string]Mutate{
+			"id":         Set("id", 1),
+			"name":       Set("name", "name"),
+			"age":        Set("age", 0),
+			"created_at": Set("created_at", now()),
+			"updated_at": Set("updated_at", now()),
+		}
+		queries = From("users").Where(Eq("id", user.ID))
+	)
+
+	adapter.On("Update", queries, mutates).Return(1, nil).Once()
+
+	assert.Nil(t, repo.Update(context.TODO(), &user))
+	assert.Equal(t, User{
+		ID:        1,
+		Name:      "name",
+		CreatedAt: now(),
+		UpdatedAt: now(),
+	}, user)
+
+	adapter.AssertExpectations(t)
+}
+
+func TestRepository_Update_compositePrimaryKeys(t *testing.T) {
+	var (
+		adapter  = &testAdapter{}
+		repo     = New(adapter)
+		userRole = UserRole{
+			UserID: 1,
+			RoleID: 2,
+		}
+		mutates = map[string]Mutate{
+			"user_id": Set("user_id", 1),
+			"role_id": Set("role_id", 2),
+		}
+		queries = From("user_roles").Where(Eq("user_id", userRole.UserID).AndEq("role_id", userRole.RoleID))
+	)
+
+	adapter.On("Update", queries, mutates).Return(1, nil).Once()
+
+	assert.Nil(t, repo.Update(context.TODO(), &userRole))
+	assert.Equal(t, UserRole{
+		UserID: 1,
+		RoleID: 2,
+	}, userRole)
+
+	adapter.AssertExpectations(t)
+}
+
+func TestRepository_Update_sets(t *testing.T) {
 	var (
 		user     = User{ID: 1}
 		adapter  = &testAdapter{}
@@ -2214,6 +2357,20 @@ func TestRepository_Delete(t *testing.T) {
 	adapter.On("Delete", From("users").Where(Eq("id", user.ID))).Return(1, nil).Once()
 
 	assert.Nil(t, repo.Delete(context.TODO(), &user))
+
+	adapter.AssertExpectations(t)
+}
+
+func TestRepository_Delete_compositePrimaryKey(t *testing.T) {
+	var (
+		adapter  = &testAdapter{}
+		repo     = New(adapter)
+		userRole = UserRole{UserID: 1, RoleID: 2}
+	)
+
+	adapter.On("Delete", From("user_roles").Where(Eq("user_id", userRole.UserID).AndEq("role_id", userRole.RoleID))).Return(1, nil).Once()
+
+	assert.Nil(t, repo.Delete(context.TODO(), &userRole))
 
 	adapter.AssertExpectations(t)
 }

--- a/structset.go
+++ b/structset.go
@@ -20,7 +20,7 @@ type Structset struct {
 // Apply mutation.
 func (s Structset) Apply(doc *Document, mut *Mutation) {
 	var (
-		pField = s.doc.PrimaryField()
+		pField = s.doc.PrimaryFields()
 		t      = now().Truncate(time.Second)
 	)
 
@@ -107,7 +107,7 @@ func (s Structset) buildAssocMany(field string, mut *Mutation) {
 
 	var (
 		col, _ = assoc.Collection()
-		pField = col.PrimaryField()
+		pField = col.PrimaryFields()
 		muts   = make([]Mutation, col.Len())
 	)
 

--- a/structset_test.go
+++ b/structset_test.go
@@ -186,6 +186,7 @@ func TestStructset_differentStruct(t *testing.T) {
 		}
 		doc      = NewDocument(&usertmp)
 		mutation = Apply(NewDocument(&user),
+			Set("id", 1),
 			Set("name", "Luffy"),
 			Set("age", 20),
 		)

--- a/util.go
+++ b/util.go
@@ -5,66 +5,6 @@ import (
 	"reflect"
 )
 
-func filterDocument(doc *Document) FilterQuery {
-	var (
-		pFields = doc.PrimaryFields()
-		pValues = doc.PrimaryValues()
-	)
-
-	return filterDocumentPrimary(pFields, pValues, FilterEqOp)
-}
-
-func filterDocumentPrimary(pFields []string, pValues []interface{}, op FilterOp) FilterQuery {
-	var filter FilterQuery
-
-	for i := range pFields {
-		filter = filter.And(FilterQuery{
-			Type:  op,
-			Field: pFields[i],
-			Value: pValues[i],
-		})
-	}
-
-	return filter
-
-}
-
-func filterCollection(col *Collection) FilterQuery {
-	var (
-		pFields = col.PrimaryFields()
-		pValues = col.PrimaryValues()
-		length  = col.Len()
-	)
-
-	return filterCollectionPrimary(pFields, pValues, length)
-}
-
-func filterCollectionPrimary(pFields []string, pValues []interface{}, length int) FilterQuery {
-	var filter FilterQuery
-
-	if len(pFields) == 1 {
-		filter = In(pFields[0], pValues[0].([]interface{})...)
-	} else {
-		var (
-			andFilters = make([]FilterQuery, length)
-		)
-
-		for i := range pValues {
-			var (
-				values = pValues[i].([]interface{})
-			)
-
-			for j := range values {
-				andFilters[j] = andFilters[j].AndEq(pFields[i], values[j])
-			}
-		}
-
-		filter = Or(andFilters...)
-	}
-
-	return filter
-}
-
 func indirect(rv reflect.Value) interface{} {
 	if rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {

--- a/util.go
+++ b/util.go
@@ -5,6 +5,66 @@ import (
 	"reflect"
 )
 
+func filterDocument(doc *Document) FilterQuery {
+	var (
+		pFields = doc.PrimaryField()
+		pValues = doc.PrimaryValue()
+	)
+
+	return filterDocumentPrimary(pFields, pValues, FilterEqOp)
+}
+
+func filterDocumentPrimary(pFields []string, pValues []interface{}, op FilterOp) FilterQuery {
+	var filter FilterQuery
+
+	for i := range pFields {
+		filter = filter.And(FilterQuery{
+			Type:  op,
+			Field: pFields[i],
+			Value: pValues[i],
+		})
+	}
+
+	return filter
+
+}
+
+func filterCollection(col *Collection) FilterQuery {
+	var (
+		pFields = col.PrimaryField()
+		pValues = col.PrimaryValue()
+		length  = col.Len()
+	)
+
+	return filterCollectionPrimary(pFields, pValues, length)
+}
+
+func filterCollectionPrimary(pFields []string, pValues []interface{}, length int) FilterQuery {
+	var filter FilterQuery
+
+	if len(pFields) == 1 {
+		filter = In(pFields[0], pValues[0].([]interface{})...)
+	} else {
+		var (
+			andFilters = make([]FilterQuery, length)
+		)
+
+		for i := range pValues {
+			var (
+				values = pValues[i].([]interface{})
+			)
+
+			for j := range values {
+				andFilters[j] = andFilters[j].AndEq(pFields[i], values[j])
+			}
+		}
+
+		filter = Or(andFilters...)
+	}
+
+	return filter
+}
+
 func indirect(rv reflect.Value) interface{} {
 	if rv.Kind() == reflect.Ptr {
 		if rv.IsNil() {

--- a/util.go
+++ b/util.go
@@ -7,8 +7,8 @@ import (
 
 func filterDocument(doc *Document) FilterQuery {
 	var (
-		pFields = doc.PrimaryField()
-		pValues = doc.PrimaryValue()
+		pFields = doc.PrimaryFields()
+		pValues = doc.PrimaryValues()
 	)
 
 	return filterDocumentPrimary(pFields, pValues, FilterEqOp)
@@ -31,8 +31,8 @@ func filterDocumentPrimary(pFields []string, pValues []interface{}, op FilterOp)
 
 func filterCollection(col *Collection) FilterQuery {
 	var (
-		pFields = col.PrimaryField()
-		pValues = col.PrimaryValue()
+		pFields = col.PrimaryFields()
+		pValues = col.PrimaryValues()
 		length  = col.Len()
 	)
 


### PR DESCRIPTION
Example:

```go
type UserRole struct {
    UserID int `db:",primary"`
    RoleID int `db:",primary"`
}
```

Limitations:
- Is not yet supported for map and changeset mutator.
- Doesn't support composite foreign keys (association to composite primary key).
- Doesn't support auto generated id.

Breaking Changes:

- Optional Primary interface now becomes:
https://github.com/Fs02/rel/pull/86/files#diff-1ce1e429022bb31e4b96b9c4fa4ae5a5L53-L56
```go
type primary interface {
    PrimaryFields() []string
    PrimaryValues() []interface{}
}
```
- Start and Finish IteratorOption now accepts variable interface argument.