### PR TITLE
supports insert all with partially specified custom primary key

### DIFF
--- a/adapter/mysql/mysql_test.go
+++ b/adapter/mysql/mysql_test.go
@@ -108,6 +108,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.InsertBelongsTo(t, repo)
 	specs.Inserts(t, repo)
 	specs.InsertAll(t, repo)
+	specs.InsertAllPartialCustomPrimary(t, repo)
 
 	// Update Specs
 	specs.Update(t, repo)

--- a/adapter/postgres/postgres_test.go
+++ b/adapter/postgres/postgres_test.go
@@ -33,7 +33,7 @@ func init() {
 		id SERIAL NOT NULL PRIMARY KEY,
 		slug VARCHAR(30) DEFAULT NULL,
 		name VARCHAR(30) NOT NULL DEFAULT '',
-		gender VARCHAR(10) NOT NULL DEFAULT '',
+		gender VARCHAR(10) NOT NULL DEFAULT '',	
 		age INT NOT NULL DEFAULT 0,
 		note varchar(50),
 		created_at TIMESTAMPTZ,
@@ -113,6 +113,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.InsertBelongsTo(t, repo)
 	specs.Inserts(t, repo)
 	specs.InsertAll(t, repo)
+	specs.InsertAllPartialCustomPrimary(t, repo)
 
 	// Update Specs
 	specs.Update(t, repo)

--- a/adapter/specs/aggregate.go
+++ b/adapter/specs/aggregate.go
@@ -51,11 +51,11 @@ func Aggregate(t *testing.T, repo rel.Repository) {
 		t.Run("Aggregate", func(t *testing.T) {
 			count, err := repo.Aggregate(ctx, query, "count", "id")
 			assert.Nil(t, err)
-			assert.True(t, count >= 0)
+			assert.NotZero(t, count)
 
 			sum, err := repo.Aggregate(ctx, query, "sum", "id")
 			assert.Nil(t, err)
-			assert.True(t, sum >= 0)
+			assert.NotZero(t, sum)
 		})
 	}
 }

--- a/adapter/specs/insert.go
+++ b/adapter/specs/insert.go
@@ -22,7 +22,7 @@ func Insert(t *testing.T, repo rel.Repository) {
 
 	err := repo.Insert(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "insert", user.Name)
 	assert.Equal(t, "male", user.Gender)
 	assert.Equal(t, 23, user.Age)
@@ -55,14 +55,14 @@ func InsertHasMany(t *testing.T, repo rel.Repository) {
 
 	err := repo.Insert(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "insert has many", user.Name)
 	assert.Equal(t, "male", user.Gender)
 	assert.Equal(t, 23, user.Age)
 
 	assert.Len(t, user.Addresses, 2)
-	assert.NotEqual(t, 0, user.Addresses[0].ID)
-	assert.NotEqual(t, 0, user.Addresses[1].ID)
+	assert.NotZero(t, user.Addresses[0].ID)
+	assert.NotZero(t, user.Addresses[1].ID)
 	assert.Equal(t, user.ID, *user.Addresses[0].UserID)
 	assert.Equal(t, user.ID, *user.Addresses[1].UserID)
 	assert.Equal(t, "primary", user.Addresses[0].Name)
@@ -88,12 +88,12 @@ func InsertHasOne(t *testing.T, repo rel.Repository) {
 
 	err := repo.Insert(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "insert has one", user.Name)
 	assert.Equal(t, "male", user.Gender)
 	assert.Equal(t, 23, user.Age)
 
-	assert.NotEqual(t, 0, user.PrimaryAddress.ID)
+	assert.NotZero(t, user.PrimaryAddress.ID)
 	assert.Equal(t, user.ID, *user.PrimaryAddress.UserID)
 	assert.Equal(t, "primary", user.PrimaryAddress.Name)
 
@@ -120,11 +120,11 @@ func InsertBelongsTo(t *testing.T, repo rel.Repository) {
 	err := repo.Insert(ctx, &address)
 	assert.Nil(t, err)
 
-	assert.NotEqual(t, 0, address.ID)
+	assert.NotZero(t, address.ID)
 	assert.Equal(t, address.User.ID, *address.UserID)
 	assert.Equal(t, "insert belongs to", address.Name)
 
-	assert.NotEqual(t, 0, address.User.ID)
+	assert.NotZero(t, address.User.ID)
 	assert.Equal(t, "zoro", address.User.Name)
 	assert.Equal(t, "male", address.User.Gender)
 	assert.Equal(t, 23, address.User.Age)
@@ -198,43 +198,64 @@ func InsertAll(t *testing.T, repo rel.Repository) {
 		&[]User{{Name: "insert", Age: 100, Note: &note}},
 		&[]User{{Note: &note}},
 		&[]User{{Name: "insert", Age: 100}, {Name: "insert too"}},
+		&[]User{{ID: 224, Name: "insert", Age: 100}, {ID: 234, Name: "insert too"}},
 		&[]Address{{}},
 		&[]Address{{Name: "work"}},
 		&[]Address{{UserID: &user.ID}},
 		&[]Address{{Name: "work", UserID: &user.ID}},
 		&[]Address{{Name: "work"}, {Name: "home"}},
+		&[]Address{{ID: 233, Name: "work"}, {ID: 235, Name: "home"}},
 	}
 
 	for _, record := range tests {
 		t.Run("InsertAll", func(t *testing.T) {
 			assert.Nil(t, repo.InsertAll(ctx, record))
-
-			switch v := record.(type) {
-			case *[]User:
-				var (
-					found []User
-					ids   = make([]int, len(*v))
-				)
-
-				for i := range *v {
-					ids[i] = int((*v)[i].ID)
-				}
-
-				repo.MustFindAll(ctx, &found, where.InInt("id", ids))
-				assert.Equal(t, found, *v)
-			case *[]Address:
-				var (
-					found []Address
-					ids   = make([]int, len(*v))
-				)
-
-				for i := range *v {
-					ids[i] = int((*v)[i].ID)
-				}
-
-				repo.MustFindAll(ctx, &found, where.InInt("id", ids))
-				assert.Equal(t, found, *v)
-			}
+			assertRecords(t, repo, record)
 		})
+	}
+}
+
+// InsertAllPartialCustomPrimary tests insert multiple specifications.
+func InsertAllPartialCustomPrimary(t *testing.T, repo rel.Repository) {
+	tests := []interface{}{
+		&[]User{{ID: 300, Name: "insert 300", Age: 100}, {Name: "insert 300+?"}},
+		&[]User{{Name: "insert 305-?", Age: 100}, {ID: 305, Name: "insert 305+?"}},
+		&[]User{{Name: "insert 310-?"}, {ID: 310, Name: "insert 310", Age: 100}, {Name: "insert 300+?"}},
+	}
+
+	for _, record := range tests {
+		t.Run("InsertAll", func(t *testing.T) {
+			assert.Nil(t, repo.InsertAll(ctx, record))
+			assertRecords(t, repo, record)
+		})
+	}
+}
+
+func assertRecords(t *testing.T, repo rel.Repository, records interface{}) {
+	switch v := records.(type) {
+	case *[]User:
+		var (
+			found []User
+			ids   = make([]int, len(*v))
+		)
+
+		for i := range *v {
+			ids[i] = int((*v)[i].ID)
+		}
+
+		repo.MustFindAll(ctx, &found, where.InInt("id", ids))
+		assert.Equal(t, found, *v)
+	case *[]Address:
+		var (
+			found []Address
+			ids   = make([]int, len(*v))
+		)
+
+		for i := range *v {
+			ids[i] = int((*v)[i].ID)
+		}
+
+		repo.MustFindAll(ctx, &found, where.InInt("id", ids))
+		assert.Equal(t, found, *v)
 	}
 }

--- a/adapter/specs/update.go
+++ b/adapter/specs/update.go
@@ -26,7 +26,7 @@ func Update(t *testing.T, repo rel.Repository) {
 
 	err := repo.Update(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "update", user.Name)
 	assert.Equal(t, "male", user.Gender)
 	assert.Equal(t, 23, user.Age)
@@ -77,12 +77,12 @@ func UpdateHasManyInsert(t *testing.T, repo rel.Repository) {
 
 	err := repo.Update(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "update insert has many", user.Name)
 
 	assert.Len(t, user.Addresses, 2)
-	assert.NotEqual(t, 0, user.Addresses[0].ID)
-	assert.NotEqual(t, 0, user.Addresses[1].ID)
+	assert.NotZero(t, user.Addresses[0].ID)
+	assert.NotZero(t, user.Addresses[1].ID)
 	assert.Equal(t, user.ID, *user.Addresses[0].UserID)
 	assert.Equal(t, user.ID, *user.Addresses[1].UserID)
 	assert.Equal(t, "primary", user.Addresses[0].Name)
@@ -107,17 +107,17 @@ func UpdateHasManyUpdate(t *testing.T, repo rel.Repository) {
 	)
 
 	repo.MustInsert(ctx, &user)
-	assert.NotEqual(t, 0, user.Addresses[0].ID)
+	assert.NotZero(t, user.Addresses[0].ID)
 
 	user.Name = "update insert has many"
 	user.Addresses[0].Name = "new address"
 
 	assert.Nil(t, repo.Update(ctx, &user))
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "update insert has many", user.Name)
 
 	assert.Len(t, user.Addresses, 1)
-	assert.NotEqual(t, 0, user.Addresses[0].ID)
+	assert.NotZero(t, user.Addresses[0].ID)
 	assert.Equal(t, user.ID, *user.Addresses[0].UserID)
 	assert.Equal(t, "new address", user.Addresses[0].Name)
 
@@ -149,12 +149,12 @@ func UpdateHasManyReplace(t *testing.T, repo rel.Repository) {
 
 	err := repo.Update(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "update insert has many", user.Name)
 
 	assert.Len(t, user.Addresses, 2)
-	assert.NotEqual(t, 0, user.Addresses[0].ID)
-	assert.NotEqual(t, 0, user.Addresses[1].ID)
+	assert.NotZero(t, user.Addresses[0].ID)
+	assert.NotZero(t, user.Addresses[1].ID)
 	assert.Equal(t, user.ID, *user.Addresses[0].UserID)
 	assert.Equal(t, user.ID, *user.Addresses[1].UserID)
 	assert.Equal(t, "primary", user.Addresses[0].Name)
@@ -182,10 +182,10 @@ func UpdateHasOneInsert(t *testing.T, repo rel.Repository) {
 
 	err := repo.Update(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "update insert has one", user.Name)
 
-	assert.NotEqual(t, 0, user.PrimaryAddress.ID)
+	assert.NotZero(t, user.PrimaryAddress.ID)
 	assert.Equal(t, user.ID, *user.PrimaryAddress.UserID)
 	assert.Equal(t, "primary", user.PrimaryAddress.Name)
 
@@ -212,10 +212,10 @@ func UpdateHasOneUpdate(t *testing.T, repo rel.Repository) {
 
 	err := repo.Update(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "update update has one", user.Name)
 
-	assert.NotEqual(t, 0, user.PrimaryAddress.ID)
+	assert.NotZero(t, user.PrimaryAddress.ID)
 	assert.Equal(t, user.ID, *user.PrimaryAddress.UserID)
 	assert.Equal(t, "updated primary", user.PrimaryAddress.Name)
 
@@ -242,10 +242,10 @@ func UpdateHasOneReplace(t *testing.T, repo rel.Repository) {
 
 	err := repo.Update(ctx, &user)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, user.ID)
+	assert.NotZero(t, user.ID)
 	assert.Equal(t, "update replace has one", user.Name)
 
-	assert.NotEqual(t, 0, user.PrimaryAddress.ID)
+	assert.NotZero(t, user.PrimaryAddress.ID)
 	assert.Equal(t, user.ID, *user.PrimaryAddress.UserID)
 	assert.Equal(t, "replaced primary", user.PrimaryAddress.Name)
 
@@ -269,10 +269,10 @@ func UpdateBelongsToInsert(t *testing.T, repo rel.Repository) {
 
 	err := repo.Update(ctx, &address)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, address.ID)
+	assert.NotZero(t, address.ID)
 	assert.Equal(t, "update address belongs to", address.Name)
 
-	assert.NotEqual(t, 0, address.User.ID)
+	assert.NotZero(t, address.User.ID)
 	assert.Equal(t, *address.UserID, address.User.ID)
 	assert.Equal(t, "inserted user", address.User.Name)
 
@@ -299,10 +299,10 @@ func UpdateBelongsToUpdate(t *testing.T, repo rel.Repository) {
 
 	err := repo.Update(ctx, &address)
 	assert.Nil(t, err)
-	assert.NotEqual(t, 0, address.ID)
+	assert.NotZero(t, address.ID)
 	assert.Equal(t, "update address belongs to", address.Name)
 
-	assert.NotEqual(t, 0, address.User.ID)
+	assert.NotZero(t, address.User.ID)
 	assert.Equal(t, *address.UserID, address.User.ID)
 	assert.Equal(t, "updated user", address.User.Name)
 

--- a/adapter/sql/adapter.go
+++ b/adapter/sql/adapter.go
@@ -151,8 +151,18 @@ func (adapter *Adapter) InsertAll(ctx context.Context, query rel.Query, primaryF
 		inc *= -1
 	}
 
-	for i := range ids {
-		ids[i] = id + int64(i*inc)
+	if primaryField != "" {
+		counter := 0
+		for i := range ids {
+			if mut, ok := bulkMutates[i][primaryField]; ok {
+				ids[i] = mut.Value
+				id = toInt64(ids[i])
+				counter = 1
+			} else {
+				ids[i] = id + int64(counter*inc)
+				counter++
+			}
+		}
 	}
 
 	return ids, nil

--- a/adapter/sql/adapter_test.go
+++ b/adapter/sql/adapter_test.go
@@ -156,6 +156,25 @@ func TestAdapter_InsertAll(t *testing.T) {
 	assert.Equal(t, "Zoro", names[1].Name)
 }
 
+func TestAdapter_InsertAll_customPrimary(t *testing.T) {
+	var (
+		adapter = open(t)
+		repo    = rel.New(adapter)
+		names   = []Name{
+			{ID: 20, Name: "Luffy"},
+			{ID: 21, Name: "Zoro"},
+		}
+	)
+	defer adapter.Close()
+
+	assert.Nil(t, repo.InsertAll(context.TODO(), &names))
+	assert.Len(t, names, 2)
+	assert.Equal(t, 20, names[0].ID)
+	assert.Equal(t, 21, names[1].ID)
+	assert.Equal(t, "Luffy", names[0].Name)
+	assert.Equal(t, "Zoro", names[1].Name)
+}
+
 func TestAdapter_Update(t *testing.T) {
 	var (
 		adapter = open(t)

--- a/adapter/sql/util.go
+++ b/adapter/sql/util.go
@@ -17,3 +17,32 @@ func ExtractString(s, left, right string) string {
 
 	return s[start+len(left) : end]
 }
+
+func toInt64(i interface{}) int64 {
+	var result int64
+
+	switch s := i.(type) {
+	case int:
+		result = int64(s)
+	case int64:
+		result = s
+	case int32:
+		result = int64(s)
+	case int16:
+		result = int64(s)
+	case int8:
+		result = int64(s)
+	case uint:
+		result = int64(s)
+	case uint64:
+		result = int64(s)
+	case uint32:
+		result = int64(s)
+	case uint16:
+		result = int64(s)
+	case uint8:
+		result = int64(s)
+	}
+
+	return result
+}

--- a/adapter/sql/util_test.go
+++ b/adapter/sql/util_test.go
@@ -15,3 +15,16 @@ func TestExtractString_notFound(t *testing.T) {
 	s := "Duplicate entry '1' for field 'slug'"
 	assert.Equal(t, "Duplicate entry '1' for field 'slug'", ExtractString(s, "key '", "'"))
 }
+
+func TestToInt64(t *testing.T) {
+	assert.Equal(t, int64(1), toInt64(int(1)))
+	assert.Equal(t, int64(1), toInt64(int64(1)))
+	assert.Equal(t, int64(1), toInt64(int32(1)))
+	assert.Equal(t, int64(1), toInt64(int16(1)))
+	assert.Equal(t, int64(1), toInt64(int8(1)))
+	assert.Equal(t, int64(1), toInt64(uint(1)))
+	assert.Equal(t, int64(1), toInt64(uint64(1)))
+	assert.Equal(t, int64(1), toInt64(uint32(1)))
+	assert.Equal(t, int64(1), toInt64(uint16(1)))
+	assert.Equal(t, int64(1), toInt64(uint8(1)))
+}

--- a/adapter/sqlite3/sqlite3_test.go
+++ b/adapter/sqlite3/sqlite3_test.go
@@ -111,6 +111,7 @@ func TestAdapter_specs(t *testing.T) {
 	specs.InsertBelongsTo(t, repo)
 	specs.Inserts(t, repo)
 	specs.InsertAll(t, repo)
+	// specs.InsertAllPartialCustomPrimary(t, repo) - not supported
 
 	// Update Specs
 	specs.Update(t, repo)


### PR DESCRIPTION
- Supported by MySQL and PostgreSQL
- Unsupported by SQLite due to unsupported insert with default keyword